### PR TITLE
Modularize room creation handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,9 @@ import { Server } from 'socket.io';
 import cors from 'cors';
 import fs from 'fs';
 import path from 'path';
-import { v4 as uuidv4 } from 'uuid';
+
+
+import { createRoomHandler } from './events/createRoom';
 
 import config from './config/config';
 import { 
@@ -104,47 +106,10 @@ io.on('connection', (socket) => {
   socket.emit(ServerEvents.ROOMS_LIST, { rooms: roomsList });
 
   // Crear una sala
-  socket.on(ClientEvents.CREATE_ROOM, (data: CreateRoomData) => {
-    const roomId = uuidv4();
-    const newRoom: GameRoom = {
-      id: roomId,
-      name: data.roomName,
-      players: [],
-      spectators: [],
-      status: 'waiting',
-      maxPlayers: config.maxPlayersPerRoom,
-      maxSpectators: config.maxSpectatorsPerRoom,
-      createdAt: new Date()
-    };
-    
-    // Añadir al jugador como primer jugador
-    const player: Player = {
-      id: socket.id,
-      username: data.username,
-      selectedCharacters: [],
-      isReady: false
-    };
-    
-    newRoom.players.push(player);
-    rooms.set(roomId, newRoom);
-    
-    // Unir al socket a la sala
-    socket.join(roomId);
-    
-    // Notificar al cliente que se unió correctamente
-    socket.emit(ServerEvents.ROOM_JOINED, { room: newRoom });
-    
-    // Actualizar la lista de salas para todos
-    io.emit(ServerEvents.ROOMS_LIST, { 
-      rooms: Array.from(rooms.values()).map(r => ({
-        id: r.id,
-        name: r.name,
-        players: r.players.length,
-        spectators: r.spectators.length,
-        status: r.status
-      }))
-    });
-  });
+  socket.on(
+    ClientEvents.CREATE_ROOM,
+    createRoomHandler(io, rooms)(socket)
+  );
 
   // Unirse a una sala
   socket.on(ClientEvents.JOIN_ROOM, (data: JoinRoomData) => {


### PR DESCRIPTION
## Summary
- break out create room logic into its own handler
- wire create room handler in the main server file

## Testing
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6846b87703848327a591feaf17f918ec