### PR TITLE
Fix combat navigation timing

### DIFF
--- a/rolmakelele/src/app/services/game.service.ts
+++ b/rolmakelele/src/app/services/game.service.ts
@@ -10,6 +10,7 @@ export class GameService {
   private socket: any;
   private username = '';
   private selectedCharacters: string[] = [];
+  private currentRoomId: string | null = null;
 
   private readonly API_BASE = 'http://localhost:3001';
 
@@ -44,6 +45,9 @@ export class GameService {
         this.zone.run(() => this.rooms$.next(data.rooms));
       });
       this.socket.on('room_joined', (data: any) => {
+        this.currentRoomId = data.room.id;
+      });
+      this.socket.on('game_started', (data: any) => {
         const roomId = data.room.id;
         this.zone.run(() => {
           this.router.navigate(['/combat', roomId]);


### PR DESCRIPTION
## Summary
- don't navigate to combat until game start event

## Testing
- `npm test` (fails: no `package.json` in repo root)
- `cd server && npm test` *(fails: Error: no test specified)*
- `cd rolmakelele && npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d0be79808327a12a01c17cae5c75