### PR TITLE
Implement auto start when second player joins

### DIFF
--- a/rolmakelele/package-lock.json
+++ b/rolmakelele/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^19.1.0",
+        "@angular/cdk": "^19.2.18",
         "@angular/common": "^19.1.0",
         "@angular/compiler": "^19.1.0",
         "@angular/core": "^19.1.0",
         "@angular/forms": "^19.1.0",
+        "@angular/material": "^19.2.18",
         "@angular/platform-browser": "^19.1.0",
         "@angular/platform-browser-dynamic": "^19.1.0",
         "@angular/router": "^19.1.0",
@@ -510,6 +512,21 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/@angular/cdk": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.2.18.tgz",
+      "integrity": "sha512-aGMHOYK/VV9PhxGTUDwiu/4ozoR/RKz8cimI+QjRxEBhzn4EPqjUDSganvlhmgS7cTN3+aqozdvF/GopMRJjLg==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.1.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^19.0.0 || ^20.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/@angular/cli": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.14.tgz",
@@ -680,6 +697,23 @@
         "@angular/common": "19.2.14",
         "@angular/core": "19.2.14",
         "@angular/platform-browser": "19.2.14",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-19.2.18.tgz",
+      "integrity": "sha512-xxedRQ9u7aiUYVrHAxASLUxnofN29xaqEGhBcHLAfOsFXdDMwDe/2ly79iKufwEs5BFBm3nfhJoarXZ3+8pucQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "19.2.18",
+        "@angular/common": "^19.0.0 || ^20.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0",
+        "@angular/forms": "^19.0.0 || ^20.0.0",
+        "@angular/platform-browser": "^19.0.0 || ^20.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -11243,7 +11277,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -11284,7 +11317,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"

--- a/rolmakelele/package.json
+++ b/rolmakelele/package.json
@@ -11,10 +11,12 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^19.1.0",
+    "@angular/cdk": "^19.2.18",
     "@angular/common": "^19.1.0",
     "@angular/compiler": "^19.1.0",
     "@angular/core": "^19.1.0",
     "@angular/forms": "^19.1.0",
+    "@angular/material": "^19.2.18",
     "@angular/platform-browser": "^19.1.0",
     "@angular/platform-browser-dynamic": "^19.1.0",
     "@angular/router": "^19.1.0",

--- a/rolmakelele/src/app/app.component.html
+++ b/rolmakelele/src/app/app.component.html
@@ -1,4 +1,11 @@
-<nav class="navbar navbar-dark bg-dark mb-3">
-  <a class="navbar-brand ms-2" routerLink="/">Rolmakelele</a>
+<nav class="navbar navbar-dark bg-dark mb-3 px-2">
+  <a class="navbar-brand" routerLink="/">Rolmakelele</a>
+  <div class="ms-auto" *ngIf="game.hasUsername()">
+    <input
+      class="form-control form-control-sm d-inline-block w-auto"
+      [(ngModel)]="username"
+      (change)="change()"
+    />
+  </div>
 </nav>
 <router-outlet></router-outlet>

--- a/rolmakelele/src/app/app.component.ts
+++ b/rolmakelele/src/app/app.component.ts
@@ -1,13 +1,28 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterOutlet, RouterLink } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { GameService } from './services/game.service';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, RouterLink],
+  imports: [RouterOutlet, RouterLink, FormsModule],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'rolmakelele';
+  username = '';
+
+  constructor(public game: GameService) {}
+
+  ngOnInit() {
+    this.username = this.game.getUsername();
+  }
+
+  change() {
+    if (this.username) {
+      this.game.setUsername(this.username);
+    }
+  }
 }

--- a/rolmakelele/src/app/app.component.ts
+++ b/rolmakelele/src/app/app.component.ts
@@ -2,11 +2,12 @@ import { Component, OnInit } from '@angular/core';
 import { RouterOutlet, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { GameService } from './services/game.service';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, RouterLink, FormsModule],
+  imports: [RouterOutlet, RouterLink, FormsModule,CommonModule],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })

--- a/rolmakelele/src/app/app.config.ts
+++ b/rolmakelele/src/app/app.config.ts
@@ -2,7 +2,7 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
-import { provideMatSnackBar } from '@angular/material/snack-bar';
+// import { provideMatSnackBar } from '@angular/material/snack-bar';
 
 import { routes } from './app.routes';
 
@@ -12,6 +12,6 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideHttpClient(),
     provideAnimations(),
-    provideMatSnackBar()
+    // provideMatSnackBar()
   ]
 };

--- a/rolmakelele/src/app/app.config.ts
+++ b/rolmakelele/src/app/app.config.ts
@@ -1,6 +1,8 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideMatSnackBar } from '@angular/material/snack-bar';
 
 import { routes } from './app.routes';
 
@@ -8,6 +10,8 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient()
+    provideHttpClient(),
+    provideAnimations(),
+    provideMatSnackBar()
   ]
 };

--- a/rolmakelele/src/app/app.routes.ts
+++ b/rolmakelele/src/app/app.routes.ts
@@ -1,23 +1,28 @@
 import { Routes } from '@angular/router';
 import { redirectIfInGameGuard } from './guards/redirect-if-in-game.guard';
 import { requireGameGuard } from './guards/require-game.guard';
+import { requireUsernameGuard } from './guards/require-username.guard';
 
 export const routes: Routes = [
-  { path: '', redirectTo: 'select', pathMatch: 'full' },
+  { path: '', redirectTo: 'name', pathMatch: 'full' },
   {
-    path: 'select',
-    canActivate: [redirectIfInGameGuard],
+    path: 'name',
+    loadComponent: () => import('./name/name.component').then(m => m.NameComponent)
+  },
+  {
+    path: 'rooms',
+    canActivate: [requireUsernameGuard, redirectIfInGameGuard],
+    loadComponent: () => import('./rooms/rooms.component').then(m => m.RoomsComponent)
+  },
+  {
+    path: 'characters/:roomId',
+    canActivate: [requireUsernameGuard],
     loadComponent: () =>
       import('./character-selection/character-selection.component').then(m => m.CharacterSelectionComponent)
   },
   {
-    path: 'rooms',
-    canActivate: [redirectIfInGameGuard],
-    loadComponent: () => import('./rooms/rooms.component').then(m => m.RoomsComponent)
-  },
-  {
     path: 'combat/:roomId',
-    canActivate: [requireGameGuard],
+    canActivate: [requireUsernameGuard, requireGameGuard],
     loadComponent: () => import('./combat/combat.component').then(m => m.CombatComponent)
   }
 ];

--- a/rolmakelele/src/app/character-selection/character-selection.component.html
+++ b/rolmakelele/src/app/character-selection/character-selection.component.html
@@ -1,5 +1,6 @@
 <div class="container">
-  <h2 class="mb-3">Elige 4 personajes</h2>
+  @if(getPlayersCount == 2)
+  {<h2 class="mb-3">Elige 4 personajes</h2>
   <div class="row">
     <div class="col-md-3 mb-3" *ngFor="let char of characters">
       <div class="card" [class.border-primary]="selected.includes(char.id)">
@@ -13,4 +14,8 @@
     </div>
   </div>
   <button class="btn btn-primary" [disabled]="selected.length !== 4" (click)="ready()">Estoy listo</button>
+}@else {
+  Esperando a que se unan más jugadores...
+  
+}
 </div>

--- a/rolmakelele/src/app/character-selection/character-selection.component.html
+++ b/rolmakelele/src/app/character-selection/character-selection.component.html
@@ -1,9 +1,5 @@
 <div class="container">
   <h2 class="mb-3">Elige 4 personajes</h2>
-  <div class="mb-3">
-    <label class="form-label">Nombre de usuario</label>
-    <input class="form-control" [(ngModel)]="username" />
-  </div>
   <div class="row">
     <div class="col-md-3 mb-3" *ngFor="let char of characters">
       <div class="card" [class.border-primary]="selected.includes(char.id)">
@@ -16,5 +12,5 @@
       </div>
     </div>
   </div>
-  <button class="btn btn-primary" [disabled]="selected.length !== 4 || !username" (click)="next()">Continuar</button>
+  <button class="btn btn-primary" [disabled]="selected.length !== 4" (click)="ready()">Estoy listo</button>
 </div>

--- a/rolmakelele/src/app/character-selection/character-selection.component.ts
+++ b/rolmakelele/src/app/character-selection/character-selection.component.ts
@@ -14,6 +14,7 @@ export class CharacterSelectionComponent implements OnInit {
   selected: string[] = [];
   characters: any[] = [];
   roomId!: string;
+  room: any;
 
   constructor(private game: GameService, private route: ActivatedRoute) {}
 
@@ -21,6 +22,7 @@ export class CharacterSelectionComponent implements OnInit {
     this.roomId = this.route.snapshot.paramMap.get('roomId')!;
     this.game.fetchCharacters();
     this.game.characters$.subscribe(c => (this.characters = c));
+    this.game.currentRoom$.subscribe(c => (this.room = c));
   }
 
   toggle(id: string) {
@@ -37,5 +39,9 @@ export class CharacterSelectionComponent implements OnInit {
       this.game.sendSelectedCharacters();
       this.game.ready();
     }
+  }
+
+  get getPlayersCount () {
+    return this.room?.players ? Object.keys(this.room.players).length : 0;
   }
 }

--- a/rolmakelele/src/app/character-selection/character-selection.component.ts
+++ b/rolmakelele/src/app/character-selection/character-selection.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { GameService } from '../services/game.service';
 
 @Component({
@@ -11,13 +11,14 @@ import { GameService } from '../services/game.service';
   templateUrl: './character-selection.component.html'
 })
 export class CharacterSelectionComponent implements OnInit {
-  username = '';
   selected: string[] = [];
   characters: any[] = [];
+  roomId!: string;
 
-  constructor(private game: GameService, private router: Router) {}
+  constructor(private game: GameService, private route: ActivatedRoute) {}
 
   ngOnInit() {
+    this.roomId = this.route.snapshot.paramMap.get('roomId')!;
     this.game.fetchCharacters();
     this.game.characters$.subscribe(c => (this.characters = c));
   }
@@ -30,11 +31,11 @@ export class CharacterSelectionComponent implements OnInit {
     }
   }
 
-  next() {
-    if (this.username && this.selected.length === 4) {
-      this.game.setUsername(this.username);
+  ready() {
+    if (this.selected.length === 4) {
       this.game.setSelectedCharacters(this.selected);
-      this.router.navigate(['/rooms']);
+      this.game.sendSelectedCharacters();
+      this.game.ready();
     }
   }
 }

--- a/rolmakelele/src/app/combat/combat.component.html
+++ b/rolmakelele/src/app/combat/combat.component.html
@@ -1,4 +1,8 @@
 <div class="container">
   <h2 class="mb-3">Combate - Sala {{ roomId }}</h2>
-  <p>Combate en progreso...</p>
+
+  <ng-container *ngIf="room$ | async as room">
+    <p *ngIf="room.status !== 'in_game'">Esperando a otro jugador...</p>
+    <p *ngIf="room.status === 'in_game'">Juego iniciado!</p>
+  </ng-container>
 </div>

--- a/rolmakelele/src/app/combat/combat.component.html
+++ b/rolmakelele/src/app/combat/combat.component.html
@@ -2,7 +2,8 @@
   <h2 class="mb-3">Combate - Sala {{ roomId }}</h2>
 
   <ng-container *ngIf="room$ | async as room">
-    <p *ngIf="room.status !== 'in_game'">Esperando a otro jugador...</p>
+    <p *ngIf="room.status === 'waiting'">Esperando a otro jugador...</p>
+    <p *ngIf="room.status === 'character_selection'">Esperando que los jugadores estén listos...</p>
     <p *ngIf="room.status === 'in_game'">Juego iniciado!</p>
   </ng-container>
 </div>

--- a/rolmakelele/src/app/combat/combat.component.ts
+++ b/rolmakelele/src/app/combat/combat.component.ts
@@ -7,7 +7,7 @@ import { Observable } from 'rxjs';
 @Component({
   selector: 'app-combat',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, CommonModule],
   templateUrl: './combat.component.html'
 })
 export class CombatComponent implements OnInit {

--- a/rolmakelele/src/app/combat/combat.component.ts
+++ b/rolmakelele/src/app/combat/combat.component.ts
@@ -1,6 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
+import { GameService } from '../services/game.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-combat',
@@ -8,10 +10,17 @@ import { ActivatedRoute } from '@angular/router';
   imports: [CommonModule],
   templateUrl: './combat.component.html'
 })
-export class CombatComponent {
+export class CombatComponent implements OnInit {
   roomId: string | null = null;
+  room$!: Observable<any | null>;
+  turn$!: Observable<any | null>;
 
-  constructor(route: ActivatedRoute) {
+  constructor(route: ActivatedRoute, private game: GameService) {
     this.roomId = route.snapshot.paramMap.get('roomId');
+  }
+
+  ngOnInit() {
+    this.room$ = this.game.currentRoom$;
+    this.turn$ = this.game.turnInfo$;
   }
 }

--- a/rolmakelele/src/app/guards/require-username.guard.ts
+++ b/rolmakelele/src/app/guards/require-username.guard.ts
@@ -1,0 +1,9 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { GameService } from '../services/game.service';
+
+export const requireUsernameGuard: CanActivateFn = () => {
+  const game = inject(GameService);
+  const router = inject(Router);
+  return game.hasUsername() ? true : router.createUrlTree(['/name']);
+};

--- a/rolmakelele/src/app/name/name.component.html
+++ b/rolmakelele/src/app/name/name.component.html
@@ -1,0 +1,5 @@
+<div class="container mt-4">
+  <h2 class="mb-3">Ingresa tu nombre</h2>
+  <input class="form-control mb-3" [(ngModel)]="username" placeholder="Nombre" />
+  <button class="btn btn-primary" (click)="save()" [disabled]="!username">Continuar</button>
+</div>

--- a/rolmakelele/src/app/name/name.component.ts
+++ b/rolmakelele/src/app/name/name.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { GameService } from '../services/game.service';
+
+@Component({
+  selector: 'app-name',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './name.component.html'
+})
+export class NameComponent implements OnInit {
+  username = '';
+
+  constructor(private game: GameService, private router: Router) {}
+
+  ngOnInit() {
+    if (this.game.hasUsername()) {
+      this.router.navigate(['/rooms']);
+    }
+  }
+
+  save() {
+    if (this.username) {
+      this.game.setUsername(this.username);
+      this.router.navigate(['/rooms']);
+    }
+  }
+}

--- a/rolmakelele/src/app/rooms/rooms.component.html
+++ b/rolmakelele/src/app/rooms/rooms.component.html
@@ -10,6 +10,7 @@
         <th>Nombre</th>
         <th>Jugadores</th>
         <th>Espectadores</th>
+        <th>Estado</th>
         <th></th>
       </tr>
     </thead>
@@ -18,6 +19,7 @@
         <td>{{ room.name }}</td>
         <td>{{ room.players }}</td>
         <td>{{ room.spectators }}</td>
+        <td>{{ room.status }}</td>
         <td>
           <button class="btn btn-primary btn-sm" (click)="join(room.id)">Unirse</button>
         </td>

--- a/rolmakelele/src/index.html
+++ b/rolmakelele/src/index.html
@@ -9,8 +9,10 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/@angular/material@17.3.9/prebuilt-themes/indigo-pink.css" rel="stylesheet">
   <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
-<body>
+<body class="mat-typography">
   <app-root></app-root>
 </body>
 </html>

--- a/rolmakelele/src/styles.scss
+++ b/rolmakelele/src/styles.scss
@@ -1,1 +1,19 @@
-/* You can add global styles to this file, and also import other style files */
+
+// Custom Theming for Angular Material
+// For more information: https://material.angular.dev/guide/theming
+@use '@angular/material' as mat;
+
+html {
+  @include mat.theme((
+    color: (
+      theme-type: light,
+      primary: mat.$azure-palette,
+      tertiary: mat.$blue-palette,
+    ),
+    typography: Roboto,
+    density: 0,
+  ));
+}/* You can add global styles to this file, and also import other style files */
+
+html, body { height: 100%; }
+body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/uuid": "^10.0.0",
         "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
         "express": "^5.1.0",
         "socket.io": "^4.8.1",
         "typescript": "^5.8.3",
@@ -527,6 +528,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/server/src/events/chatMessage.ts
+++ b/server/src/events/chatMessage.ts
@@ -46,7 +46,4 @@ export function registerChatMessage(io: Server, socket: Socket, rooms: Map<strin
       isSpectator
     });
   });
-
-  // Desconexión
-  socket.on('disconnect', () => {
-})}
+}

--- a/server/src/events/disconnect.ts
+++ b/server/src/events/disconnect.ts
@@ -77,7 +77,7 @@ export function registerDisconnect(io: Server, socket: Socket, rooms: Map<string
     }
     
     // Actualizar la lista de salas para todos
-    io.emit(ServerEvents.ROOMS_LIST, { 
+    io.emit(ServerEvents.ROOMS_LIST, {
       rooms: Array.from(rooms.values()).map(r => ({
         id: r.id,
         name: r.name,
@@ -86,5 +86,5 @@ export function registerDisconnect(io: Server, socket: Socket, rooms: Map<string
         status: r.status
       }))
     });
+  });
 }
-  )}

--- a/server/src/events/joinRoom.ts
+++ b/server/src/events/joinRoom.ts
@@ -43,6 +43,9 @@ export function registerJoinRoom(
     };
 
     room.players.push(player);
+    if (room.players.length === config.maxPlayersPerRoom && room.status === 'waiting') {
+      room.status = 'character_selection';
+    }
     socket.join(data.roomId);
     socket.emit(ServerEvents.ROOM_JOINED, { room });
 

--- a/server/src/events/ready.ts
+++ b/server/src/events/ready.ts
@@ -45,7 +45,7 @@ export function registerReady(
     }
 
     const playerIndex = playerRoom.players.findIndex(p => p.id === socket.id);
-    playerRoom.players[playerIndex].isReady = true;
+    playerRoom.players[playerIndex].isReady = !playerRoom.players[playerIndex].isReady;
 
     const allReady = playerRoom.players.length === config.maxPlayersPerRoom &&
                      playerRoom.players.every(p => p.isReady);

--- a/server/src/events/selectCharacters.ts
+++ b/server/src/events/selectCharacters.ts
@@ -66,54 +66,6 @@ export function registerSelectCharacters(
       playerRoom.status = 'character_selection';
     }
 
-    const allSelected =
-      playerRoom.players.length === config.maxPlayersPerRoom &&
-      playerRoom.players.every(
-        p => p.selectedCharacters.length === config.maxCharactersPerPlayer
-      );
-
-    if (allSelected) {
-      playerRoom.status = 'in_game';
-      const turnOrder: { playerId: string; characterIndex: number; speed: number }[] = [];
-
-      for (const p of playerRoom.players) {
-        for (let i = 0; i < p.selectedCharacters.length; i++) {
-          turnOrder.push({
-            playerId: p.id,
-            characterIndex: i,
-            speed:
-              p.selectedCharacters[i].currentStats?.speed ||
-              p.selectedCharacters[i].stats.speed
-          });
-        }
-      }
-
-      turnOrder.sort((a, b) => b.speed - a.speed);
-      playerRoom.turnOrder = turnOrder;
-      playerRoom.currentTurn = turnOrder[0];
-
-      io.to(playerRoom.id).emit(ServerEvents.GAME_STARTED, {
-        room: playerRoom,
-        turnOrder
-      });
-
-      io.to(playerRoom.id).emit(ServerEvents.TURN_STARTED, {
-        playerId: turnOrder[0].playerId,
-        characterIndex: turnOrder[0].characterIndex,
-        timeRemaining: config.turnTimeLimit
-      });
-
-      io.emit(ServerEvents.ROOMS_LIST, {
-        rooms: Array.from(rooms.values()).map(r => ({
-          id: r.id,
-          name: r.name,
-          players: r.players.length,
-          spectators: r.spectators.length,
-          status: r.status
-        }))
-      });
-    } else {
-      io.to(playerRoom.id).emit(ServerEvents.ROOM_UPDATED, { room: playerRoom });
-    }
+    io.to(playerRoom.id).emit(ServerEvents.ROOM_UPDATED, { room: playerRoom });
   });
 }

--- a/server/src/events/selectCharacters.ts
+++ b/server/src/events/selectCharacters.ts
@@ -66,6 +66,54 @@ export function registerSelectCharacters(
       playerRoom.status = 'character_selection';
     }
 
-    io.to(playerRoom.id).emit(ServerEvents.ROOM_UPDATED, { room: playerRoom });
+    const allSelected =
+      playerRoom.players.length === config.maxPlayersPerRoom &&
+      playerRoom.players.every(
+        p => p.selectedCharacters.length === config.maxCharactersPerPlayer
+      );
+
+    if (allSelected) {
+      playerRoom.status = 'in_game';
+      const turnOrder: { playerId: string; characterIndex: number; speed: number }[] = [];
+
+      for (const p of playerRoom.players) {
+        for (let i = 0; i < p.selectedCharacters.length; i++) {
+          turnOrder.push({
+            playerId: p.id,
+            characterIndex: i,
+            speed:
+              p.selectedCharacters[i].currentStats?.speed ||
+              p.selectedCharacters[i].stats.speed
+          });
+        }
+      }
+
+      turnOrder.sort((a, b) => b.speed - a.speed);
+      playerRoom.turnOrder = turnOrder;
+      playerRoom.currentTurn = turnOrder[0];
+
+      io.to(playerRoom.id).emit(ServerEvents.GAME_STARTED, {
+        room: playerRoom,
+        turnOrder
+      });
+
+      io.to(playerRoom.id).emit(ServerEvents.TURN_STARTED, {
+        playerId: turnOrder[0].playerId,
+        characterIndex: turnOrder[0].characterIndex,
+        timeRemaining: config.turnTimeLimit
+      });
+
+      io.emit(ServerEvents.ROOMS_LIST, {
+        rooms: Array.from(rooms.values()).map(r => ({
+          id: r.id,
+          name: r.name,
+          players: r.players.length,
+          spectators: r.spectators.length,
+          status: r.status
+        }))
+      });
+    } else {
+      io.to(playerRoom.id).emit(ServerEvents.ROOM_UPDATED, { room: playerRoom });
+    }
   });
 }


### PR DESCRIPTION
## Summary
- start game automatically once both players have chosen characters
- update room state when second player joins
- clean up disconnect and chat message handlers
- add frontend handlers for automatic game start

## Testing
- `npm run build` *(fails: cannot find modules)*
- `npm test` in frontend *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d6e7d8cc83278012d6d1464aaaaf