### PR TITLE
Fix room disconnect flow

### DIFF
--- a/rolmakelele/src/app/character-selection/character-selection.component.html
+++ b/rolmakelele/src/app/character-selection/character-selection.component.html
@@ -14,6 +14,7 @@
     </div>
   </div>
   <button class="btn btn-primary" [disabled]="selected.length !== 4" (click)="ready()">Estoy listo</button>
+  <button class="btn btn-secondary ms-2" (click)="leave()">Salir</button>
 }@else {
   Esperando a que se unan más jugadores...
   

--- a/rolmakelele/src/app/character-selection/character-selection.component.ts
+++ b/rolmakelele/src/app/character-selection/character-selection.component.ts
@@ -41,6 +41,12 @@ export class CharacterSelectionComponent implements OnInit {
     }
   }
 
+  leave() {
+    this.game.leaveGame();
+    this.game.fetchRooms();
+    this.game.connect();
+  }
+
   get getPlayersCount () {
     return this.room?.players ? Object.keys(this.room.players).length : 0;
   }

--- a/rolmakelele/src/app/combat/combat.component.html
+++ b/rolmakelele/src/app/combat/combat.component.html
@@ -6,4 +6,5 @@
     <p *ngIf="room.status === 'character_selection'">Esperando que los jugadores estén listos...</p>
     <p *ngIf="room.status === 'in_game'">Juego iniciado!</p>
   </ng-container>
+  <button class="btn btn-secondary mt-3" (click)="leave()">Salir</button>
 </div>

--- a/rolmakelele/src/app/combat/combat.component.ts
+++ b/rolmakelele/src/app/combat/combat.component.ts
@@ -23,4 +23,10 @@ export class CombatComponent implements OnInit {
     this.room$ = this.game.currentRoom$;
     this.turn$ = this.game.turnInfo$;
   }
+
+  leave() {
+    this.game.leaveGame();
+    this.game.fetchRooms();
+    this.game.connect();
+  }
 }

--- a/rolmakelele/src/app/guards/require-game.guard.ts
+++ b/rolmakelele/src/app/guards/require-game.guard.ts
@@ -7,7 +7,7 @@ export const requireGameGuard: CanActivateFn = (route: ActivatedRouteSnapshot) =
   const router = inject(Router);
   const current = game.getCurrentRoomId();
   if (!current) {
-    return router.createUrlTree(['/select']);
+    return router.createUrlTree(['/rooms']);
   }
   const roomId = route.paramMap.get('roomId');
   if (roomId !== current) {

--- a/server/src/events/disconnect.ts
+++ b/server/src/events/disconnect.ts
@@ -22,20 +22,15 @@ export function registerDisconnect(io: Server, socket: Socket, rooms: Map<string
         // Si era el último jugador, eliminar la sala
         if (room.players.length === 0 && room.spectators.length === 0) {
           rooms.delete(roomId);
-        } else if (room.status === 'in_game') {
-          // Si el juego estaba en curso, el otro jugador gana automáticamente
-          room.status = 'finished';
-          
-          // Determinar el ganador (el otro jugador)
-          const winner = room.players[0];
-          if (winner) {
-            room.winner = winner.id;
-            
-            // Notificar que el juego ha terminado
-            io.to(roomId).emit(ServerEvents.GAME_ENDED, {
-              winnerId: winner.id,
-              winnerUsername: winner.username
-            });
+        } else {
+          // Reiniciar la sala para una nueva partida
+          room.status = 'waiting';
+          room.turnOrder = undefined;
+          room.currentTurn = undefined;
+          room.winner = undefined;
+          for (const p of room.players) {
+            p.selectedCharacters = [];
+            p.isReady = false;
           }
         }
         

--- a/server/src/events/leaveRoom.ts
+++ b/server/src/events/leaveRoom.ts
@@ -17,20 +17,15 @@ export function registerLeaveRoom(io: Server, socket: Socket, rooms: Map<string,
         // Si era el último jugador, eliminar la sala
         if (room.players.length === 0 && room.spectators.length === 0) {
           rooms.delete(roomId);
-        } else if (room.status === 'in_game') {
-          // Si el juego estaba en curso, el otro jugador gana automáticamente
-          room.status = 'finished';
-          
-          // Determinar el ganador (el otro jugador)
-          const winner = room.players[0];
-          if (winner) {
-            room.winner = winner.id;
-            
-            // Notificar que el juego ha terminado
-            io.to(roomId).emit(ServerEvents.GAME_ENDED, {
-              winnerId: winner.id,
-              winnerUsername: winner.username
-            });
+        } else {
+          // Reiniciar la sala para una nueva partida
+          room.status = 'waiting';
+          room.turnOrder = undefined;
+          room.currentTurn = undefined;
+          room.winner = undefined;
+          for (const p of room.players) {
+            p.selectedCharacters = [];
+            p.isReady = false;
           }
         }
         


### PR DESCRIPTION
## Summary
- reset rooms to `waiting` when a player leaves or disconnects
- correct `requireGame` guard redirect to `/rooms`
- persist room id in session storage so refresh reconnects
- allow leaving rooms from UI and service
- show `Salir` button during combat and selection screens

## Testing
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm test` in `rolmakelele` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470eee3e3083279287d1014b1af32c