### PR TITLE
Handle disconnections with reconnection window

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -38,6 +38,7 @@ const io = new Server(server, {
 });
 
 const rooms: Map<string, GameRoom> = new Map();
+const disconnectTimers: Map<string, NodeJS.Timeout> = new Map();
 let characters: Character[] = [];
 
 try {
@@ -73,14 +74,14 @@ io.on('connection', socket => {
   });
 
   registerCreateRoom(io, socket, rooms);
-  registerJoinRoom(io, socket, rooms);
+  registerJoinRoom(io, socket, rooms, disconnectTimers);
   registerJoinAsSpectator(io, socket, rooms);
   registerSelectCharacters(io, socket, rooms);
   registerReady(io, socket, rooms);
   registerPerformAction(io, socket, rooms);
   registerLeaveRoom(io, socket, rooms);
   registerChatMessage(io, socket, rooms);
-  registerDisconnect(io, socket, rooms);
+  registerDisconnect(io, socket, rooms, disconnectTimers);
 });
 
 server.listen(config.port, () => {

--- a/server/src/types/game.types.ts
+++ b/server/src/types/game.types.ts
@@ -59,6 +59,8 @@ export interface Player {
   username: string;
   selectedCharacters: CharacterState[];
   isReady: boolean;
+  isDisconnected?: boolean;
+  disconnectedAt?: number;
 }
 
 // Estados posibles de una sala


### PR DESCRIPTION
## Summary
- track temporary player disconnections
- allow players to rejoin a running match
- auto-end game if opponent is disconnected for more than 15 seconds
- notify opponent on disconnect and reconnection

## Testing
- `npm run build` in `server`
- `npm run build` in `rolmakelele`

------
https://chatgpt.com/codex/tasks/task_e_68472fa274e883279fb3e6d60c1b9410