### PR TITLE
Fix guards to validate room existence

### DIFF
--- a/rolmakelele/src/app/guards/redirect-if-in-game.guard.ts
+++ b/rolmakelele/src/app/guards/redirect-if-in-game.guard.ts
@@ -2,10 +2,16 @@ import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { GameService } from '../services/game.service';
 
-export const redirectIfInGameGuard: CanActivateFn = () => {
+export const redirectIfInGameGuard: CanActivateFn = async () => {
   const game = inject(GameService);
   const router = inject(Router);
-  return game.isInGame()
-    ? router.createUrlTree(['/combat', game.getCurrentRoomId()!])
-    : true;
+  const current = game.getCurrentRoomId();
+  if (current) {
+    const exists = await game.roomExists(current);
+    if (exists) {
+      return router.createUrlTree(['/combat', current]);
+    }
+    game.clearRoom();
+  }
+  return true;
 };

--- a/rolmakelele/src/app/guards/require-game.guard.ts
+++ b/rolmakelele/src/app/guards/require-game.guard.ts
@@ -2,13 +2,20 @@ import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
 import { GameService } from '../services/game.service';
 
-export const requireGameGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
+export const requireGameGuard: CanActivateFn = async (route: ActivatedRouteSnapshot) => {
   const game = inject(GameService);
   const router = inject(Router);
   const current = game.getCurrentRoomId();
   if (!current) {
     return router.createUrlTree(['/rooms']);
   }
+
+  const exists = await game.roomExists(current);
+  if (!exists) {
+    game.clearRoom();
+    return router.createUrlTree(['/rooms']);
+  }
+
   const roomId = route.paramMap.get('roomId');
   if (roomId !== current) {
     return router.createUrlTree(['/combat', current]);


### PR DESCRIPTION
## Summary
- add `roomExists` and `clearRoom` helpers in GameService
- clear room on `ROOM_NOT_FOUND` errors
- update guards to verify if room exists before allowing navigation

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm test --silent` in server *(fails: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_684747ca1e9c8327aaea914604a8527c