### PR TITLE
Improve frontend typing

### DIFF
--- a/rolmakelele/src/app/character-selection/character-selection.component.ts
+++ b/rolmakelele/src/app/character-selection/character-selection.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { GameService } from '../services/game.service';
+import { Character, GameRoom } from '../models/game.models';
 
 @Component({
   selector: 'app-character-selection',
@@ -12,9 +13,9 @@ import { GameService } from '../services/game.service';
 })
 export class CharacterSelectionComponent implements OnInit {
   selected: string[] = [];
-  characters: any[] = [];
+  characters: Character[] = [];
   roomId!: string;
-  room: any;
+  room: GameRoom | null = null;
 
   constructor(private game: GameService, private route: ActivatedRoute) {}
 

--- a/rolmakelele/src/app/combat/character-box/character-box.component.ts
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { CharacterState } from '../../models/game.models';
 
 @Component({
   selector: 'app-character-box',
@@ -9,7 +10,7 @@ import { CommonModule } from '@angular/common';
   styleUrl: './character-box.component.scss'
 })
 export class CharacterBoxComponent {
-  @Input() character: any;
+  @Input() character: CharacterState | null = null;
 
   get healthPercent(): number {
     if (!this.character) {

--- a/rolmakelele/src/app/combat/combat.component.ts
+++ b/rolmakelele/src/app/combat/combat.component.ts
@@ -3,6 +3,8 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { GameService } from '../services/game.service';
 import { Observable } from 'rxjs';
+import { GameRoom, CharacterState, Player } from '../models/game.models';
+import { TurnStartedData } from '../models/socket.models';
 import { CharacterBoxComponent } from './character-box/character-box.component';
 
 @Component({
@@ -14,8 +16,8 @@ import { CharacterBoxComponent } from './character-box/character-box.component';
 })
 export class CombatComponent implements OnInit {
   roomId: string | null = null;
-  room$!: Observable<any | null>;
-  turn$!: Observable<any | null>;
+  room$!: Observable<GameRoom | null>;
+  turn$!: Observable<TurnStartedData | null>;
   rows = [0, 1, 2, 3];
 
   constructor(route: ActivatedRoute, private game: GameService) {
@@ -35,29 +37,29 @@ export class CombatComponent implements OnInit {
     return this.myPlayerId === playerId;
   }
 
-  getCharacterName(room: any, playerId: string, characterIndex: number): string {
-    const player = room?.players.find((p: any) => p.id === playerId);
+  getCharacterName(room: GameRoom | null, playerId: string, characterIndex: number): string {
+    const player = room?.players.find((p: Player) => p.id === playerId);
     return player?.selectedCharacters?.[characterIndex]?.name || '';
   }
 
-  getMyCharacters(room: any): any[] {
+  getMyCharacters(room: GameRoom | null): CharacterState[] {
     return (
-      room?.players.find((p: any) => p.id === this.myPlayerId)?.selectedCharacters || []
+      room?.players.find((p: Player) => p.id === this.myPlayerId)?.selectedCharacters || []
     );
   }
 
-  getOpponentCharacters(room: any): any[] {
+  getOpponentCharacters(room: GameRoom | null): CharacterState[] {
     return (
-      room?.players.find((p: any) => p.id !== this.myPlayerId)?.selectedCharacters || []
+      room?.players.find((p: Player) => p.id !== this.myPlayerId)?.selectedCharacters || []
     );
   }
 
-  isMyTurn(room: any): boolean {
+  isMyTurn(room: GameRoom): boolean {
     return room.currentTurn.playerId === this.myPlayerId;
   }
-  
-  getSelectedCharacterSkills(room: any, playerId: string): any[] {
-    const player = room?.players.find((p: any) => p.id === playerId);
+
+  getSelectedCharacterSkills(room: GameRoom, playerId: string): CharacterState[] {
+    const player = room?.players.find((p: Player) => p.id === playerId);
     return player?.selectedCharacters || [];
   }
 

--- a/rolmakelele/src/app/models/game.models.ts
+++ b/rolmakelele/src/app/models/game.models.ts
@@ -1,0 +1,100 @@
+export interface Stats {
+  speed: number;
+  health: number;
+  attack: number;
+  defense: number;
+}
+
+export type EffectType = 'damage' | 'heal' | 'buff' | 'debuff';
+export type EffectTarget = 'self' | 'opponent';
+export type StatType = 'speed' | 'health' | 'attack' | 'defense';
+
+export interface Effect {
+  type: EffectType;
+  target: EffectTarget;
+  value: number;
+  stat?: StatType;
+  duration?: number;
+  ignoreDefense?: number;
+}
+
+export interface Ability {
+  name: string;
+  description: string;
+  effects: Effect[];
+  cooldown: number;
+  currentCooldown?: number;
+}
+
+export interface Character {
+  id: string;
+  name: string;
+  stats: Stats;
+  abilities: Ability[];
+  currentStats?: Stats;
+  activeEffects?: {
+    effect: Effect;
+    remainingDuration: number;
+  }[];
+}
+
+export interface CharacterState extends Character {
+  currentHealth: number;
+  isAlive: boolean;
+}
+
+export interface Player {
+  id: string;
+  username: string;
+  selectedCharacters: CharacterState[];
+  isReady: boolean;
+  isDisconnected?: boolean;
+  disconnectedAt?: number;
+}
+
+export type RoomStatus = 'waiting' | 'character_selection' | 'in_game' | 'finished';
+
+export interface GameRoom {
+  id: string;
+  name: string;
+  players: Player[];
+  spectators: string[];
+  status: RoomStatus;
+  maxPlayers: number;
+  maxSpectators: number;
+  currentTurn?: {
+    playerId: string;
+    characterIndex: number;
+  };
+  turnOrder?: {
+    playerId: string;
+    characterIndex: number;
+    speed: number;
+  }[];
+  winner?: string;
+  createdAt: Date;
+}
+
+export interface GameAction {
+  playerId: string;
+  sourceCharacterIndex: number;
+  targetPlayerId: string;
+  targetCharacterIndex: number;
+  abilityIndex: number;
+}
+
+export interface ActionResult {
+  playerId: string;
+  sourceCharacterIndex: number;
+  targetPlayerId: string;
+  targetCharacterIndex: number;
+  ability: Ability;
+  effects: {
+    type: EffectType;
+    target: 'source' | 'target';
+    stat?: StatType;
+    value: number;
+    duration?: number;
+  }[];
+  isDead?: boolean;
+}

--- a/rolmakelele/src/app/models/socket.models.ts
+++ b/rolmakelele/src/app/models/socket.models.ts
@@ -1,0 +1,108 @@
+import { GameRoom, GameAction, ActionResult, Character, CharacterState } from './game.models';
+
+export enum ClientEvents {
+  JOIN_ROOM = 'join_room',
+  CREATE_ROOM = 'create_room',
+  LEAVE_ROOM = 'leave_room',
+  SELECT_CHARACTERS = 'select_characters',
+  READY = 'ready',
+  PERFORM_ACTION = 'perform_action',
+  JOIN_AS_SPECTATOR = 'join_as_spectator',
+  CHAT_MESSAGE = 'chat_message'
+}
+
+export enum ServerEvents {
+  ROOMS_LIST = 'rooms_list',
+  ROOM_JOINED = 'room_joined',
+  ROOM_UPDATED = 'room_updated',
+  GAME_STARTED = 'game_started',
+  TURN_STARTED = 'turn_started',
+  ACTION_RESULT = 'action_result',
+  GAME_ENDED = 'game_ended',
+  ERROR = 'game_error',
+  CHARACTERS_LIST = 'characters_list',
+  CHAT_MESSAGE = 'chat_message'
+}
+
+export interface JoinRoomData {
+  roomId: string;
+  username: string;
+}
+
+export interface CreateRoomData {
+  roomName: string;
+  username: string;
+}
+
+export interface SelectCharactersData {
+  characterIds: string[];
+}
+
+export interface PerformActionData extends GameAction {}
+
+export interface ChatMessageData {
+  message: string;
+}
+
+export interface RoomsListData {
+  rooms: {
+    id: string;
+    name: string;
+    players: number;
+    spectators: number;
+    status: string;
+  }[];
+}
+
+export interface RoomJoinedData {
+  room: GameRoom;
+}
+
+export interface RoomUpdatedData {
+  room: GameRoom;
+}
+
+export interface GameStartedData {
+  room: GameRoom;
+  turnOrder: {
+    playerId: string;
+    characterIndex: number;
+    speed: number;
+  }[];
+}
+
+export interface TurnStartedData {
+  playerId: string;
+  characterIndex: number;
+  timeRemaining: number | null;
+}
+
+export interface ActionResultData {
+  result: ActionResult;
+  nextTurn?: {
+    playerId: string;
+    characterIndex: number;
+  };
+}
+
+export interface GameEndedData {
+  winnerId: string;
+  winnerUsername: string;
+  reason?: string;
+}
+
+export interface ErrorData {
+  message: string;
+  code: string;
+}
+
+export interface CharactersListData {
+  characters: Character[];
+}
+
+export interface ChatMessageReceivedData {
+  username: string;
+  message: string;
+  timestamp: Date;
+  isSpectator: boolean;
+}

--- a/rolmakelele/src/app/rooms/rooms.component.ts
+++ b/rolmakelele/src/app/rooms/rooms.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { GameService } from '../services/game.service';
+import { RoomsListData } from '../models/socket.models';
 
 @Component({
   selector: 'app-rooms',
@@ -10,7 +11,7 @@ import { GameService } from '../services/game.service';
   templateUrl: './rooms.component.html'
 })
 export class RoomsComponent implements OnInit {
-  rooms: any[] = [];
+  rooms: RoomsListData['rooms'] = [];
   newRoomName = '';
 
   constructor(public game: GameService) {}


### PR DESCRIPTION
## Summary
- add models for game and socket data
- use the new models across frontend services and components

## Testing
- `npm run build` *(fails: ng not found)*
- `npm run build` in `server` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68489ad5b5808327b01f954be59797aa