### PR TITLE
Add typed models for frontend

### DIFF
--- a/rolmakelele/src/app/character-selection/character-selection.component.ts
+++ b/rolmakelele/src/app/character-selection/character-selection.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { GameService } from '../services/game.service';
+import { Character, GameRoom } from '../models/game.types';
 
 @Component({
   selector: 'app-character-selection',
@@ -12,9 +13,9 @@ import { GameService } from '../services/game.service';
 })
 export class CharacterSelectionComponent implements OnInit {
   selected: string[] = [];
-  characters: any[] = [];
+  characters: Character[] = [];
   roomId!: string;
-  room: any;
+  room: GameRoom | null = null;
 
   constructor(private game: GameService, private route: ActivatedRoute) {}
 

--- a/rolmakelele/src/app/combat/character-box/character-box.component.ts
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { CharacterState } from '../../models/game.types';
 
 @Component({
   selector: 'app-character-box',
@@ -9,7 +10,7 @@ import { CommonModule } from '@angular/common';
   styleUrl: './character-box.component.scss'
 })
 export class CharacterBoxComponent {
-  @Input() character: any;
+  @Input() character: CharacterState | null = null;
 
   get healthPercent(): number {
     if (!this.character) {

--- a/rolmakelele/src/app/combat/combat.component.ts
+++ b/rolmakelele/src/app/combat/combat.component.ts
@@ -3,6 +3,8 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { GameService } from '../services/game.service';
 import { Observable } from 'rxjs';
+import { GameRoom, CharacterState, Ability } from '../models/game.types';
+import { TurnStartedData } from '../models/socket.types';
 import { CharacterBoxComponent } from './character-box/character-box.component';
 
 @Component({
@@ -14,8 +16,8 @@ import { CharacterBoxComponent } from './character-box/character-box.component';
 })
 export class CombatComponent implements OnInit {
   roomId: string | null = null;
-  room$!: Observable<any | null>;
-  turn$!: Observable<any | null>;
+  room$!: Observable<GameRoom | null>;
+  turn$!: Observable<TurnStartedData | null>;
   rows = [0, 1, 2, 3];
 
   constructor(route: ActivatedRoute, private game: GameService) {
@@ -35,31 +37,35 @@ export class CombatComponent implements OnInit {
     return this.myPlayerId === playerId;
   }
 
-  getCharacterName(room: any, playerId: string, characterIndex: number): string {
-    const player = room?.players.find((p: any) => p.id === playerId);
+  getCharacterName(
+    room: GameRoom,
+    playerId: string,
+    characterIndex: number
+  ): string {
+    const player = room?.players.find(p => p.id === playerId);
     return player?.selectedCharacters?.[characterIndex]?.name || '';
   }
 
-  getMyCharacters(room: any): any[] {
+  getMyCharacters(room: GameRoom): CharacterState[] {
     return (
-      room?.players.find((p: any) => p.id === this.myPlayerId)?.selectedCharacters || []
+      room?.players.find(p => p.id === this.myPlayerId)?.selectedCharacters || []
     );
   }
 
-  getOpponentCharacters(room: any): any[] {
+  getOpponentCharacters(room: GameRoom): CharacterState[] {
     return (
-      room?.players.find((p: any) => p.id !== this.myPlayerId)?.selectedCharacters || []
+      room?.players.find(p => p.id !== this.myPlayerId)?.selectedCharacters || []
     );
   }
 
-  isMyTurn(room: any): boolean {
-    return room.currentTurn.playerId === this.myPlayerId;
+  isMyTurn(room: GameRoom): boolean {
+    return room.currentTurn?.playerId === this.myPlayerId;
   }
 
-  getCurrentCharacterAbilities(room: any): any[] {
+  getCurrentCharacterAbilities(room: GameRoom): Ability[] {
     const turn = room.currentTurn;
     if (!turn) return [];
-    const player = room.players.find((p: any) => p.id === turn.playerId);
+    const player = room.players.find(p => p.id === turn.playerId);
     return player?.selectedCharacters?.[turn.characterIndex]?.abilities || [];
   }
 

--- a/rolmakelele/src/app/models/game.types.ts
+++ b/rolmakelele/src/app/models/game.types.ts
@@ -1,0 +1,115 @@
+/**
+ * Interfaces y tipos para el juego de rol por turnos
+ */
+
+// Estadísticas básicas de un personaje
+export interface Stats {
+  speed: number;
+  health: number;
+  attack: number;
+  defense: number;
+}
+
+// Tipos de efectos para las habilidades
+export type EffectType = 'damage' | 'heal' | 'buff' | 'debuff';
+export type EffectTarget = 'self' | 'opponent';
+export type StatType = 'speed' | 'health' | 'attack' | 'defense';
+
+// Definición de un efecto
+export interface Effect {
+  type: EffectType;
+  target: EffectTarget;
+  value: number;
+  stat?: StatType;
+  duration?: number;
+  ignoreDefense?: number;
+}
+
+// Definición de una habilidad
+export interface Ability {
+  name: string;
+  description: string;
+  effects: Effect[];
+  cooldown: number;
+  currentCooldown?: number;
+}
+
+// Definición de un personaje
+export interface Character {
+  id: string;
+  name: string;
+  stats: Stats;
+  abilities: Ability[];
+  currentStats?: Stats;
+  activeEffects?: {
+    effect: Effect;
+    remainingDuration: number;
+  }[];
+}
+
+// Estado de un personaje en juego
+export interface CharacterState extends Character {
+  currentHealth: number;
+  isAlive: boolean;
+}
+
+// Definición de un jugador
+export interface Player {
+  id: string;
+  username: string;
+  selectedCharacters: CharacterState[];
+  isReady: boolean;
+  isDisconnected?: boolean;
+  disconnectedAt?: number;
+}
+
+// Estados posibles de una sala
+export type RoomStatus = 'waiting' | 'character_selection' | 'in_game' | 'finished';
+
+// Definición de una sala de juego
+export interface GameRoom {
+  id: string;
+  name: string;
+  players: Player[];
+  spectators: string[];
+  status: RoomStatus;
+  maxPlayers: number;
+  maxSpectators: number;
+  currentTurn?: {
+    playerId: string;
+    characterIndex: number;
+  };
+  turnOrder?: {
+    playerId: string;
+    characterIndex: number;
+    speed: number;
+  }[];
+  winner?: string;
+  createdAt: Date;
+}
+
+// Definición de una acción en el juego
+export interface GameAction {
+  playerId: string;
+  sourceCharacterIndex: number;
+  targetPlayerId: string;
+  targetCharacterIndex: number;
+  abilityIndex: number;
+}
+
+// Resultado de una acción en el juego
+export interface ActionResult {
+  playerId: string;
+  sourceCharacterIndex: number;
+  targetPlayerId: string;
+  targetCharacterIndex: number;
+  ability: Ability;
+  effects: {
+    type: EffectType;
+    target: 'source' | 'target';
+    stat?: StatType;
+    value: number;
+    duration?: number;
+  }[];
+  isDead?: boolean;
+}

--- a/rolmakelele/src/app/models/socket.types.ts
+++ b/rolmakelele/src/app/models/socket.types.ts
@@ -1,0 +1,117 @@
+/**
+ * Tipos y eventos para la comunicación con Socket.IO
+ */
+import { Character, GameRoom, GameAction, ActionResult, CharacterState } from './game.types';
+
+// Eventos del cliente al servidor
+enum ClientEvents {
+  JOIN_ROOM = 'join_room',
+  CREATE_ROOM = 'create_room',
+  LEAVE_ROOM = 'leave_room',
+  SELECT_CHARACTERS = 'select_characters',
+  READY = 'ready',
+  PERFORM_ACTION = 'perform_action',
+  JOIN_AS_SPECTATOR = 'join_as_spectator',
+  CHAT_MESSAGE = 'chat_message'
+}
+export { ClientEvents };
+
+// Eventos del servidor al cliente
+enum ServerEvents {
+  ROOMS_LIST = 'rooms_list',
+  ROOM_JOINED = 'room_joined',
+  ROOM_UPDATED = 'room_updated',
+  GAME_STARTED = 'game_started',
+  TURN_STARTED = 'turn_started',
+  ACTION_RESULT = 'action_result',
+  GAME_ENDED = 'game_ended',
+  ERROR = 'game_error',
+  CHARACTERS_LIST = 'characters_list',
+  CHAT_MESSAGE = 'chat_message'
+}
+export { ServerEvents };
+
+// Datos enviados por el cliente
+export interface JoinRoomData {
+  roomId: string;
+  username: string;
+}
+
+export interface CreateRoomData {
+  roomName: string;
+  username: string;
+}
+
+export interface SelectCharactersData {
+  characterIds: string[];
+}
+
+export interface PerformActionData extends GameAction {}
+
+export interface ChatMessageData {
+  message: string;
+}
+
+// Datos enviados por el servidor
+export interface RoomsListData {
+  rooms: {
+    id: string;
+    name: string;
+    players: number;
+    spectators: number;
+    status: string;
+  }[];
+}
+
+export interface RoomJoinedData {
+  room: GameRoom;
+}
+
+export interface RoomUpdatedData {
+  room: GameRoom;
+}
+
+export interface GameStartedData {
+  room: GameRoom;
+  turnOrder: {
+    playerId: string;
+    characterIndex: number;
+    speed: number;
+  }[];
+}
+
+export interface TurnStartedData {
+  playerId: string;
+  characterIndex: number;
+  timeRemaining: number | null;
+}
+
+export interface ActionResultData {
+  result: ActionResult;
+  nextTurn?: {
+    playerId: string;
+    characterIndex: number;
+  };
+}
+
+export interface GameEndedData {
+  winnerId: string;
+  winnerUsername: string;
+  reason?: string;
+}
+
+export interface ErrorData {
+  message: string;
+  code: string;
+}
+
+export interface CharactersListData {
+  characters: Character[];
+}
+
+export interface ChatMessageReceivedData {
+  username: string;
+  message: string;
+  timestamp: Date;
+  isSpectator: boolean;
+}

--- a/rolmakelele/src/app/rooms/rooms.component.ts
+++ b/rolmakelele/src/app/rooms/rooms.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { GameService } from '../services/game.service';
+import { RoomsListData } from '../models/socket.types';
 
 @Component({
   selector: 'app-rooms',
@@ -10,7 +11,7 @@ import { GameService } from '../services/game.service';
   templateUrl: './rooms.component.html'
 })
 export class RoomsComponent implements OnInit {
-  rooms: any[] = [];
+  rooms: RoomsListData['rooms'] = [];
   newRoomName = '';
 
   constructor(public game: GameService) {}


### PR DESCRIPTION
## Summary
- introduce frontend models mirroring backend types
- type GameService and components using new models
- replace socket event strings with enums

## Testing
- `npm run build` in `rolmakelele`
- `npm run build` in `server`

------
https://chatgpt.com/codex/tasks/task_e_68489cc75ce483278dd9d149c774a30f