### PR TITLE
Add chat UI and client messaging

### DIFF
--- a/rolmakelele/src/app/chat/chat.component.html
+++ b/rolmakelele/src/app/chat/chat.component.html
@@ -1,0 +1,21 @@
+<div class="chat">
+  <div class="messages" #messagesContainer>
+    <div *ngFor="let msg of messages" class="message">
+      <span class="tag" [ngClass]="msg.isSpectator ? 'spectator' : 'player'">
+        {{ msg.isSpectator ? 'Espectador' : 'Jugador' }}
+      </span>
+      <strong>{{ msg.username }}:</strong>
+      <span>{{ msg.message }}</span>
+    </div>
+  </div>
+  <form class="input-group mt-2" (ngSubmit)="send()">
+    <input
+      type="text"
+      class="form-control"
+      placeholder="Escribe un mensaje..."
+      [(ngModel)]="newMessage"
+      name="message"
+    />
+    <button class="btn btn-primary" type="submit">Enviar</button>
+  </form>
+</div>

--- a/rolmakelele/src/app/chat/chat.component.html
+++ b/rolmakelele/src/app/chat/chat.component.html
@@ -9,7 +9,7 @@
           msg.isSystem ? 'Sistema' : msg.isSpectator ? 'Espectador' : 'Jugador'
         }}
       </span>
-      <strong>{{ msg.username }}:</strong>
+      <strong>{{ msg.username }}: </strong>
       <span>{{ msg.message }}</span>
     </div>
   </div>

--- a/rolmakelele/src/app/chat/chat.component.html
+++ b/rolmakelele/src/app/chat/chat.component.html
@@ -1,8 +1,13 @@
 <div class="chat">
   <div class="messages" #messagesContainer>
     <div *ngFor="let msg of messages" class="message">
-      <span class="tag" [ngClass]="msg.isSpectator ? 'spectator' : 'player'">
-        {{ msg.isSpectator ? 'Espectador' : 'Jugador' }}
+      <span
+        class="tag"
+        [ngClass]="msg.isSystem ? 'system' : (msg.isSpectator ? 'spectator' : 'player')"
+      >
+        {{
+          msg.isSystem ? 'Sistema' : msg.isSpectator ? 'Espectador' : 'Jugador'
+        }}
       </span>
       <strong>{{ msg.username }}:</strong>
       <span>{{ msg.message }}</span>

--- a/rolmakelele/src/app/chat/chat.component.scss
+++ b/rolmakelele/src/app/chat/chat.component.scss
@@ -28,3 +28,7 @@
 .tag.spectator {
   color: #6c757d;
 }
+
+.tag.system {
+  color: #dc3545;
+}

--- a/rolmakelele/src/app/chat/chat.component.scss
+++ b/rolmakelele/src/app/chat/chat.component.scss
@@ -1,0 +1,30 @@
+.chat {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 0.5rem;
+  height: 200px;
+  display: flex;
+  flex-direction: column;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.message {
+  margin-bottom: 0.25rem;
+}
+
+.tag {
+  font-size: 0.75rem;
+  margin-right: 0.25rem;
+}
+
+.tag.player {
+  color: #0d6efd;
+}
+
+.tag.spectator {
+  color: #6c757d;
+}

--- a/rolmakelele/src/app/chat/chat.component.ts
+++ b/rolmakelele/src/app/chat/chat.component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { GameService } from '../services/game.service';
+import { ChatMessageReceivedData } from '../models/socket.types';
+
+@Component({
+  selector: 'app-chat',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './chat.component.html',
+  styleUrl: './chat.component.scss'
+})
+export class ChatComponent implements OnInit {
+  messages: ChatMessageReceivedData[] = [];
+  newMessage = '';
+  @ViewChild('messagesContainer') messagesContainer!: ElementRef<HTMLDivElement>;
+
+  constructor(private game: GameService) {}
+
+  ngOnInit() {
+    this.game.chatMessages$.subscribe(m => {
+      this.messages = m;
+      setTimeout(() => {
+        if (this.messagesContainer) {
+          const el = this.messagesContainer.nativeElement;
+          el.scrollTop = el.scrollHeight;
+        }
+      });
+    });
+  }
+
+  send() {
+    const msg = this.newMessage.trim();
+    if (msg) {
+      this.game.sendChatMessage(msg);
+      this.newMessage = '';
+    }
+  }
+}

--- a/rolmakelele/src/app/combat/combat.component.html
+++ b/rolmakelele/src/app/combat/combat.component.html
@@ -1,6 +1,7 @@
 <div class="container">
-  <h2 class="mb-3">Combate - Sala {{ roomId }}</h2>
-
+  @if(room$ |async; as room){
+  <h2 class="mb-3">Combate - Sala {{ room.name }} - {{room.players[0].username}} vs {{room.players[1].username}}</h2>
+ 
   <div class="row g-2 h-100">
     <div
       class="col-12 offset-1 d-flex align-items-center justify-content-center"
@@ -8,7 +9,7 @@
     >
       <div
         class="turn-order d-flex position-relative"
-        *ngIf="room$ | async as room"
+        
       >
         <ng-container *ngIf="turn$ | async as turn">
           <div
@@ -101,4 +102,5 @@
   <button class="btn btn-outline-danger mt-3 w-100" (click)="leave()">
     Rendirse
   </button>
+   }
 </div>

--- a/rolmakelele/src/app/combat/combat.component.html
+++ b/rolmakelele/src/app/combat/combat.component.html
@@ -96,6 +96,8 @@
     </p>
   </ng-container>
 
+  <app-chat class="mt-3"></app-chat>
+
   <button class="btn btn-outline-danger mt-3 w-100" (click)="leave()">
     Rendirse
   </button>

--- a/rolmakelele/src/app/combat/combat.component.ts
+++ b/rolmakelele/src/app/combat/combat.component.ts
@@ -6,11 +6,12 @@ import { Observable } from 'rxjs';
 import { GameRoom, CharacterState, Ability } from '../models/game.types';
 import { TurnStartedData } from '../models/socket.types';
 import { CharacterBoxComponent } from './character-box/character-box.component';
+import { ChatComponent } from '../chat/chat.component';
 
 @Component({
   selector: 'app-combat',
   standalone: true,
-  imports: [CommonModule, CharacterBoxComponent],
+  imports: [CommonModule, CharacterBoxComponent, ChatComponent],
   templateUrl: './combat.component.html',
   styleUrl: './combat.component.scss'
 })

--- a/rolmakelele/src/app/models/socket.types.ts
+++ b/rolmakelele/src/app/models/socket.types.ts
@@ -114,4 +114,5 @@ export interface ChatMessageReceivedData {
   message: string;
   timestamp: Date;
   isSpectator: boolean;
+  isSystem: boolean;
 }

--- a/server/src/events/chatMessage.ts
+++ b/server/src/events/chatMessage.ts
@@ -43,7 +43,8 @@ export function registerChatMessage(io: Server, socket: Socket, rooms: Map<strin
       username,
       message: data.message,
       timestamp: new Date(),
-      isSpectator
+      isSpectator,
+      isSystem: false
     });
   });
 }

--- a/server/src/events/disconnect.ts
+++ b/server/src/events/disconnect.ts
@@ -51,7 +51,8 @@ export function registerDisconnect(
           username: 'Sistema',
           message: `${player.username} se ha desconectado`,
           timestamp: new Date(),
-          isSpectator: false
+          isSpectator: false,
+          isSystem: true
         });
       }
       
@@ -74,7 +75,8 @@ export function registerDisconnect(
             username: 'Sistema',
             message: `Un espectador se ha desconectado`,
             timestamp: new Date(),
-            isSpectator: true
+            isSpectator: true,
+            isSystem: true
           });
         }
       }

--- a/server/src/events/joinAsSpectator.ts
+++ b/server/src/events/joinAsSpectator.ts
@@ -36,7 +36,8 @@ export function registerJoinAsSpectator(
       username: 'Sistema',
       message: `${data.username} se ha unido como espectador`,
       timestamp: new Date(),
-      isSpectator: true
+      isSpectator: true,
+      isSystem: true
     });
   });
 }

--- a/server/src/events/joinRoom.ts
+++ b/server/src/events/joinRoom.ts
@@ -53,7 +53,8 @@ export function registerJoinRoom(
           username: 'Sistema',
           message: `${data.username} se ha reconectado`,
           timestamp: new Date(),
-          isSpectator: false
+          isSpectator: false,
+          isSystem: true
         });
         return;
       } else {

--- a/server/src/types/socket.types.ts
+++ b/server/src/types/socket.types.ts
@@ -112,5 +112,6 @@ export interface ChatMessageReceivedData {
   message: string;
   timestamp: Date;
   isSpectator: boolean;
+  isSystem: boolean;
 }
 


### PR DESCRIPTION
## Summary
- add Chat component for in-game messaging
- support CHAT_MESSAGE events in GameService
- include ChatComponent on combat screen

## Testing
- `npm run build`
- `npm test -- --watch=false` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6849b95544e48327a5857e337b8f748f