### PR TITLE
Improve ability selector accordion

### DIFF
--- a/rolmakelele/src/app/ability-selector/ability-selector.component.html
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.html
@@ -10,13 +10,38 @@
   </label>
 </div> -->
 <mat-accordion>
-  <mat-expansion-panel hideToggle disabled="true">
+  <mat-expansion-panel *ngFor="let ab of abilities" hideToggle>
     <mat-expansion-panel-header>
-      <mat-panel-title> {{character.name}} </mat-panel-title>
-      <mat-panel-description> 
-      <button class="btn btn-outline-primary">Añadir</button>
+      <mat-panel-title>
+        <img
+          src="https://via.placeholder.com/40"
+          alt="icon"
+          width="40"
+          height="40"
+          class="me-2"
+        />
+        {{ ab.name }}
+      </mat-panel-title>
+      <mat-panel-description>
+        <button
+          class="btn btn-outline-primary btn-sm"
+          (click)="toggleAbility(ab.id)"
+        >
+          {{ selectedIds.includes(ab.id) ? 'Quitar' : 'Añadir' }}
+        </button>
       </mat-panel-description>
     </mat-expansion-panel-header>
-    <p>This is the primary content of the panel.</p>
+    <p>{{ ab.description }}</p>
+    <ul>
+      <li *ngFor="let effect of ab.effects">
+        <span>{{ effect.type }} sobre {{ effect.target }}</span>
+        <span *ngIf="effect.stat"> ({{ effect.stat }})</span>
+        <span> : {{ effect.value }}</span>
+        <span *ngIf="effect.duration"> ({{ effect.duration }} turnos)</span>
+        <span *ngIf="effect.ignoreDefense">
+          (ignora defensa {{ effect.ignoreDefense * 100 }}%)
+        </span>
+      </li>
+    </ul>
   </mat-expansion-panel>
 </mat-accordion>

--- a/rolmakelele/src/app/ability-selector/ability-selector.component.html
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.html
@@ -14,7 +14,7 @@
     <mat-expansion-panel-header>
       <mat-panel-title>
         <img
-          src="https://via.placeholder.com/40"
+          src="https://placehold.co/40x40/png"
           alt="icon"
           width="40"
           height="40"

--- a/rolmakelele/src/app/character-selection/character-selection.component.html
+++ b/rolmakelele/src/app/character-selection/character-selection.component.html
@@ -2,7 +2,7 @@
   <ng-container *ngIf="getPlayersCount === 2; else waiting">
     <h2 class="mb-3">Elige 4 personajes</h2>
     <div class="row">
-      <div class="col-md-3 mb-3" *ngFor="let char of characters">
+      <div class="col-md-6 mb-3" *ngFor="let char of characters">
         <div class="card" [class.border-primary]="isSelected(char.id)">
           <div class="card-body">
             <!-- <h5 class="card-title">{{ char.name }}</h5> -->

--- a/rolmakelele/src/app/character-selection/character-selection.component.ts
+++ b/rolmakelele/src/app/character-selection/character-selection.component.ts
@@ -58,10 +58,13 @@ export class CharacterSelectionComponent implements OnInit {
   }
 
   onAbilitySelectionChange(charId: string, abilityIds: string[]) {
-    const entry = this.selected.find(c => c.id === charId);
-    if (entry) {
-      entry.abilityIds = abilityIds;
+    let entry = this.selected.find(c => c.id === charId);
+    if (!entry) {
+      if (this.selected.length >= 4) return;
+      entry = { id: charId, abilityIds: [] };
+      this.selected.push(entry);
     }
+    entry.abilityIds = abilityIds;
   }
 
   ready() {


### PR DESCRIPTION
## Summary
- add ability accordion listing each ability
- show placeholder icon, name and add/remove button in header
- display ability description and effects when expanded

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ed5248a88327a29a8b6a95c7ff62