### PR TITLE
Improve character card UI with stats and selection

### DIFF
--- a/rolmakelele/src/app/ability-selector/ability-selector.component.html
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.html
@@ -20,6 +20,7 @@
           height="40"
           class="me-2"
         />
+        
         {{ ab.name }}
       </mat-panel-title>
       <mat-panel-description>

--- a/rolmakelele/src/app/character-selection/character-selection.component.html
+++ b/rolmakelele/src/app/character-selection/character-selection.component.html
@@ -4,18 +4,27 @@
     <div class="row">
       <div class="col-md-6 mb-3" *ngFor="let char of characters">
         <div class="card" [class.border-primary]="isSelected(char.id)">
+          <img src="https://placehold.co/600x200/png" class="card-img-top" alt="placeholder" />
           <div class="card-body">
-            <!-- <h5 class="card-title">{{ char.name }}</h5> -->
-            <!-- <button class="btn btn-sm btn-outline-primary" (click)="toggle(char.id)">
-              {{ isSelected(char.id) ? 'Quitar' : 'Añadir' }}
-            </button> -->
-            
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <h5 class="card-title mb-0">{{ char.name }}</h5>
+              <button class="btn btn-sm btn-outline-primary" (click)="toggle(char.id)">
+                {{ isSelected(char.id) ? 'Quitar' : 'Seleccionar' }}
+              </button>
+            </div>
+            <ul class="list-unstyled small mb-3">
+              <li>Velocidad: {{ char.stats.speed }}</li>
+              <li>Vida: {{ char.stats.health }}</li>
+              <li>Ataque: {{ char.stats.attack }}</li>
+              <li>Defensa: {{ char.stats.defense }}</li>
+            </ul>
+            <ng-container *ngIf="isSelected(char.id)">
               <app-ability-selector
                 [character]="char"
                 [selectedIds]="getSelectedAbilities(char.id)"
                 (selectionChange)="onAbilitySelectionChange(char.id, $event)"
               ></app-ability-selector>
-           
+            </ng-container>
           </div>
         </div>
       </div>

--- a/rolmakelele/src/app/character-selection/character-selection.component.html
+++ b/rolmakelele/src/app/character-selection/character-selection.component.html
@@ -7,7 +7,7 @@
           <img src="https://placehold.co/600x200/png" class="card-img-top" alt="placeholder" />
           <div class="card-body">
             <div class="d-flex justify-content-between align-items-center mb-2">
-              <h5 class="card-title mb-0">{{ char.name }}</h5>
+              <h1 class="card-title mb-0">{{ char.name }}</h1>
               <button class="btn btn-sm btn-outline-primary" (click)="toggle(char.id)">
                 {{ isSelected(char.id) ? 'Quitar' : 'Seleccionar' }}
               </button>

--- a/rolmakelele/src/app/character-selection/character-selection.component.ts
+++ b/rolmakelele/src/app/character-selection/character-selection.component.ts
@@ -58,12 +58,8 @@ export class CharacterSelectionComponent implements OnInit {
   }
 
   onAbilitySelectionChange(charId: string, abilityIds: string[]) {
-    let entry = this.selected.find(c => c.id === charId);
-    if (!entry) {
-      if (this.selected.length >= 4) return;
-      entry = { id: charId, abilityIds: [] };
-      this.selected.push(entry);
-    }
+    const entry = this.selected.find(c => c.id === charId);
+    if (!entry) return;
     entry.abilityIds = abilityIds;
   }
 


### PR DESCRIPTION
## Summary
- show character placeholder image and name in selection cards
- add select/remove button per character
- display stats (velocidad, vida, ataque, defensa)
- only enable ability selection when character is selected

## Testing
- `npm run build` within `rolmakelele`
- `npm run build` within `server`
- `npm test` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6849f21803508327884c8996b2682675