### PR TITLE
Add matTooltip with character stats

### DIFF
--- a/rolmakelele/src/app/combat/character-box/character-box.component.html
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.html
@@ -3,6 +3,8 @@
   *ngIf="character"
   [class.selectable]="selectable"
   (click)="onClick()"
+  [matTooltip]="statsTpl"
+  matTooltipPosition="above"
 >
   <div class="fw-bold">{{ character.name }}</div>
   <div class="progress mt-1" style="height: 8px;">
@@ -17,3 +19,13 @@
   </div>
   <small>{{ character.currentHealth }} / {{ character.stats.health }}</small>
 </div>
+
+<ng-template #statsTpl>
+  <div class="text-start">
+    <div *ngFor="let key of statKeys">
+      <span [style.color]="getStatColor(key)">
+        {{ statLabels[key] }}: {{ getCurrentStat(key) }}
+      </span>
+    </div>
+  </div>
+</ng-template>

--- a/rolmakelele/src/app/combat/character-box/character-box.component.ts
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.ts
@@ -1,11 +1,13 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { CharacterState } from '../../models/game.types';
+import { CharacterState, Stats } from '../../models/game.types';
+import { LABELS_MAP } from '../../constants/stats.map';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-character-box',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, MatTooltipModule],
   templateUrl: './character-box.component.html',
   styleUrl: './character-box.component.scss'
 })
@@ -14,11 +16,42 @@ export class CharacterBoxComponent {
   @Input() selectable = false;
   @Output() selected = new EventEmitter<void>();
 
+  readonly statKeys: (keyof Stats)[] = [
+    'speed',
+    'health',
+    'attack',
+    'defense',
+    'specialAttack',
+    'specialDefense',
+    'critical',
+    'evasion'
+  ];
+
+  readonly statLabels = LABELS_MAP;
+
   get healthPercent(): number {
     if (!this.character) {
       return 0;
     }
     return (this.character.currentHealth / this.character.stats.health) * 100;
+  }
+
+  getCurrentStat(key: keyof Stats): number {
+    if (!this.character) return 0;
+    return this.character.currentStats?.[key] ?? this.character.stats[key];
+  }
+
+  getStatColor(key: keyof Stats): string {
+    if (!this.character) return '';
+    const base = this.character.stats[key];
+    const current = this.getCurrentStat(key);
+    if (current < base) {
+      return 'red';
+    }
+    if (current > base) {
+      return 'blue';
+    }
+    return 'inherit';
   }
 
   onClick() {


### PR DESCRIPTION
## Summary
- show current character stats on hover using Angular Material tooltip
- color stats red when below base and blue when above base

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_684b2bf564b483278cd1dce1573185d3