### PR TITLE
Add tooltip stats display

### DIFF
--- a/rolmakelele/package-lock.json
+++ b/rolmakelele/package-lock.json
@@ -18,6 +18,8 @@
         "@angular/platform-browser": "^19.1.0",
         "@angular/platform-browser-dynamic": "^19.1.0",
         "@angular/router": "^19.1.0",
+        "@ngx-popovers/core": "^19.0.0",
+        "@ngx-popovers/tooltip": "^19.0.0",
         "chart.js": "^4.4.9",
         "ng2-charts": "^8.0.0",
         "rxjs": "~7.8.0",
@@ -2902,6 +2904,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.1.tgz",
+      "integrity": "sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.7.1",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@inquirer/checkbox": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.8.tgz",
@@ -3978,6 +4008,34 @@
         "@angular/compiler-cli": "^19.0.0 || ^19.2.0-next.0",
         "typescript": ">=5.5 <5.9",
         "webpack": "^5.54.0"
+      }
+    },
+    "node_modules/@ngx-popovers/core": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-popovers/core/-/core-19.0.0.tgz",
+      "integrity": "sha512-43XsBcskQOyR6kLl+b3uAEu2PANvpOJndUZte6yx5GUHPFvwS/HR1tqr8rfllDPiHafmHWl+TgyaWaZexcR0qw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=19.0.0",
+        "@angular/core": ">=19.0.0",
+        "@floating-ui/dom": "^1.5.0"
+      }
+    },
+    "node_modules/@ngx-popovers/tooltip": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-popovers/tooltip/-/tooltip-19.0.0.tgz",
+      "integrity": "sha512-Zr5MsgxBbgP/v9FZKHkMaMancdx3ziYPubpCmv9RqpltcPmvCX9BgDHh+IFdS95Xd6wtfX8qkZ6BZFuHJPc8Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=19.0.0",
+        "@angular/core": ">=19.0.0",
+        "@ngx-popovers/core": ">=19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/rolmakelele/package.json
+++ b/rolmakelele/package.json
@@ -20,6 +20,8 @@
     "@angular/platform-browser": "^19.1.0",
     "@angular/platform-browser-dynamic": "^19.1.0",
     "@angular/router": "^19.1.0",
+    "@ngx-popovers/core": "^19.0.0",
+    "@ngx-popovers/tooltip": "^19.0.0",
     "chart.js": "^4.4.9",
     "ng2-charts": "^8.0.0",
     "rxjs": "~7.8.0",

--- a/rolmakelele/src/app/combat/character-box/character-box.component.html
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.html
@@ -3,6 +3,10 @@
   *ngIf="character"
   [class.selectable]="selectable"
   (click)="onClick()"
+  [ngxTooltip]="statsTpl"
+  placement="top"
+  arrow
+  [autoUpdate]="true"
 >
   <div class="fw-bold">{{ character.name }}</div>
   <div class="progress mt-1" style="height: 8px;">
@@ -17,3 +21,13 @@
   </div>
   <small>{{ character.currentHealth }} / {{ character.stats.health }}</small>
 </div>
+
+<ng-template #statsTpl>
+  <div class="stats-tooltip">
+    <div *ngFor="let key of statKeys">
+      <span [style.color]="getStatColor(key)">
+        {{ labels[key] }}: {{ getStatValue(key) }}
+      </span>
+    </div>
+  </div>
+</ng-template>

--- a/rolmakelele/src/app/combat/character-box/character-box.component.scss
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.scss
@@ -8,3 +8,11 @@
   border: 2px dashed #ccc;
   padding: 0.25rem;
 }
+
+.stats-tooltip {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}

--- a/rolmakelele/src/app/combat/character-box/character-box.component.ts
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.ts
@@ -1,11 +1,13 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { CharacterState } from '../../models/game.types';
+import { CharacterState, Stats } from '../../models/game.types';
+import { NgxTooltip } from '@ngx-popovers/tooltip';
+import { LABELS_MAP } from '../../constants/stats.map';
 
 @Component({
   selector: 'app-character-box',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, NgxTooltip],
   templateUrl: './character-box.component.html',
   styleUrl: './character-box.component.scss'
 })
@@ -13,6 +15,18 @@ export class CharacterBoxComponent {
   @Input() character: CharacterState | null = null;
   @Input() selectable = false;
   @Output() selected = new EventEmitter<void>();
+
+  readonly statKeys: (keyof Stats)[] = [
+    'speed',
+    'health',
+    'attack',
+    'defense',
+    'specialAttack',
+    'specialDefense',
+    'critical',
+    'evasion'
+  ];
+  readonly labels = LABELS_MAP;
 
   get healthPercent(): number {
     if (!this.character) {
@@ -25,5 +39,19 @@ export class CharacterBoxComponent {
     if (this.selectable) {
       this.selected.emit();
     }
+  }
+
+  getStatValue(stat: keyof Stats): number {
+    if (!this.character) return 0;
+    return this.character.currentStats?.[stat] ?? this.character.stats[stat];
+  }
+
+  getStatColor(stat: keyof Stats): string {
+    if (!this.character) return 'black';
+    const base = this.character.stats[stat];
+    const current = this.character.currentStats?.[stat] ?? base;
+    if (current < base) return 'red';
+    if (current > base) return 'blue';
+    return 'black';
   }
 }


### PR DESCRIPTION
## Summary
- install `@ngx-popovers/tooltip` and its core package
- show character stats in a tooltip when hovering over a character
- color stats above base in blue and below base in red

## Testing
- `npm test --silent -- --watch=false` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684b38c5e13483278f59a0c0c714bf54