### PR TITLE
Add character/move types with bonus effect

### DIFF
--- a/rolmakelele/src/app/ability-selector/ability-selector.component.html
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.html
@@ -20,7 +20,9 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
     <p>
-      {{ ab.description }} <small class="text-muted">({{ ab.category }})</small>
+      {{ ab.description }}
+      <small class="text-muted">({{ ab.category }})</small>
+      <span *ngIf="ab.type" class="badge bg-secondary ms-2">{{ ab.type }}</span>
     </p>
     <ul>
       <li *ngFor="let effect of ab.effects">

--- a/rolmakelele/src/app/character-selection/character-selection.component.html
+++ b/rolmakelele/src/app/character-selection/character-selection.component.html
@@ -19,6 +19,14 @@
                 {{ isSelected(char.id) ? "Quitar" : "Seleccionar" }}
               </button>
             </div>
+            <div class="mb-2">
+              <span
+                *ngFor="let t of char.types"
+                class="badge me-1"
+                [style.backgroundColor]="t.color"
+                >{{ t.name }}</span
+              >
+            </div>
 
             <ng-container *ngIf="isSelected(char.id)">
               <ul class="list-unstyled small mb-3">

--- a/rolmakelele/src/app/combat/character-box/character-box.component.html
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.html
@@ -25,6 +25,14 @@
   [autoUpdate]="true"
 >
   <div class="fw-bold">{{ character.name }}</div>
+  <div class="mb-1">
+    <span
+      *ngFor="let t of character.types"
+      class="badge me-1"
+      [style.backgroundColor]="t.color"
+      >{{ t.name }}</span
+    >
+  </div>
 
   <div class="progress mt-2" style="height: 8px;">
     <div

--- a/rolmakelele/src/app/models/game.types.ts
+++ b/rolmakelele/src/app/models/game.types.ts
@@ -44,6 +44,8 @@ export interface Ability {
   description: string;
   /** Tipo de habilidad: fisico, especial o de estado */
   category: 'physical' | 'special' | 'status';
+  /** Tipo elemental o afinidad de la habilidad */
+  type?: string;
   effects: Effect[];
   /** Ruta a la imagen que representa la habilidad */
   img?: string;
@@ -54,6 +56,7 @@ export interface Character {
   id: string;
   name: string;
   stats: Stats;
+  types: CharacterType[];
   availableAbilities: Ability[];
   abilities: Ability[];
   currentStats?: Stats;
@@ -61,6 +64,12 @@ export interface Character {
     effect: Effect;
     remainingDuration: number;
   }[];
+}
+
+export interface CharacterType {
+  id: string;
+  name: string;
+  color: string;
 }
 
 // Estado de un personaje en juego

--- a/server/data/characters.json
+++ b/server/data/characters.json
@@ -3,7 +3,7 @@
     {
       "id": "c001",
       "name": "Tewi",
-      "types": ["Programador", "Bebedor"],
+      "types": ["Progamador"],
       "stats": {
         "speed": 135,
         "health": 100,
@@ -23,6 +23,7 @@
     {
       "id": "c002",
       "name": "Wanolo",
+      "types": ["Musico"],
       "stats": {
         "speed": 135,
         "health": 100,
@@ -42,6 +43,7 @@
     {
       "id": "c003",
       "name": "Visente",
+      "types": ["Friki"],
       "stats": {
         "speed": 135,
         "health": 100,
@@ -61,6 +63,7 @@
     {
       "id": "c004",
       "name": "Jaime",
+      "types": ["Techno"],
       "stats": {
         "speed": 135,
         "health": 100,

--- a/server/data/moves_data.json
+++ b/server/data/moves_data.json
@@ -12,7 +12,8 @@
         }
       ],
       "id": "m001",
-      "img": "/public/assets/abilities/insult.png"
+      "img": "/public/assets/abilities/insult.png",
+      "type": "Friki"
     },
     {
       "name": "Puñetazo",
@@ -43,7 +44,8 @@
         }
       ],
       "id": "m003",
-      "img": "/public/assets/abilities/drink.png"
+      "img": "/public/assets/abilities/drink.png",
+      "type": "Musico"
     }
 
   ]

--- a/server/src/config/config.ts
+++ b/server/src/config/config.ts
@@ -11,6 +11,7 @@ interface ServerConfig {
   maxAbilitiesPerCharacter: number;
   turnTimeLimit: number; // en segundos
   charactersDataPath: string;
+  characterTypesDataPath: string;
   movesDataPath: string;
   postmanCollectionPath: string;
 }
@@ -24,6 +25,7 @@ const config: ServerConfig = {
   maxAbilitiesPerCharacter: 4,
   turnTimeLimit: 30,
   charactersDataPath: './data/characters.json',
+  characterTypesDataPath: './data/character.types.json',
   movesDataPath: './data/moves_data.json',
   postmanCollectionPath: './data/rolmakelele_postman_collection.json'
 };

--- a/server/src/events/performAction/effects.ts
+++ b/server/src/events/performAction/effects.ts
@@ -24,14 +24,18 @@ export function applyAbilityEffects(
   ability: Ability,
   actionResult: ActionResult
 ) {
+  const sameType =
+    ability.type && sourceCharacter.types?.some(t => t.name === ability.type);
+
   for (const effect of ability.effects) {
+    const modifiedEffect = { ...effect, value: effect.value * (sameType ? 1.2 : 1) };
     if (effect.target === 'self') {
       if (effect.type === 'buff') {
-        applyBuff(sourceCharacter, effect, actionResult, 'source');
+        applyBuff(sourceCharacter, modifiedEffect, actionResult, 'source');
       } else if (effect.type === 'heal') {
-        applyHeal(sourceCharacter, effect, actionResult, 'source');
+        applyHeal(sourceCharacter, modifiedEffect, actionResult, 'source');
       } else if (effect.type === 'debuff') {
-        applyDebuff(sourceCharacter, effect, actionResult, 'source');
+        applyDebuff(sourceCharacter, modifiedEffect, actionResult, 'source');
       }
     } else if (effect.target === 'opponent') {
       if (effect.type === 'damage') {
@@ -50,7 +54,7 @@ export function applyAbilityEffects(
 
         const { amount, attackPortion, reduction, isCrit } = calculateDamage(
           ability,
-          effect.value,
+          modifiedEffect.value,
           effect.ignoreDefense,
           sourceCharacter,
           targetCharacter
@@ -65,7 +69,7 @@ export function applyAbilityEffects(
 
         actionResult.effects.push({ type: 'damage', target: 'target', value: amount });
 
-        const calcParts = [`Base ${effect.value}%`];
+        const calcParts = [`Base ${modifiedEffect.value}%`];
         if (attackPortion) calcParts.push(`Atk ${attackPortion.toFixed(2)}`);
         if (reduction) calcParts.push(`- Def ${reduction.toFixed(2)}`);
         if (isCrit) calcParts.push('x2 Crit');
@@ -80,11 +84,11 @@ export function applyAbilityEffects(
           isSystem: true
         });
       } else if (effect.type === 'debuff') {
-        applyDebuff(targetCharacter, effect, actionResult, 'target');
+        applyDebuff(targetCharacter, modifiedEffect, actionResult, 'target');
       } else if (effect.type === 'heal') {
-        applyHeal(targetCharacter, effect, actionResult, 'target');
+        applyHeal(targetCharacter, modifiedEffect, actionResult, 'target');
       } else if (effect.type === 'buff') {
-        applyBuff(targetCharacter, effect, actionResult, 'target');
+        applyBuff(targetCharacter, modifiedEffect, actionResult, 'target');
       }
     }
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,7 +9,8 @@ import path from 'path';
 import config from './config/config';
 import {
   GameRoom,
-  Character
+  Character,
+  CharacterType
 } from './types/game.types';
 import { ServerEvents } from './types/socket.types';
 
@@ -56,6 +57,7 @@ const rooms: Map<string, GameRoom> = new Map();
 const disconnectTimers: Map<string, NodeJS.Timeout> = new Map();
 let characters: Character[] = [];
 let moves: Map<string, any> = new Map();
+let characterTypes: CharacterType[] = [];
 
 try {
   const movesRaw = fs.readFileSync(
@@ -65,6 +67,12 @@ try {
   const parsedMoves = JSON.parse(movesRaw).moves;
   moves = new Map(parsedMoves.map((m: any) => [m.id, m]));
 
+  const typesRaw = fs.readFileSync(
+    path.resolve(process.cwd(), config.characterTypesDataPath),
+    'utf-8'
+  );
+  characterTypes = JSON.parse(typesRaw);
+
   const data = fs.readFileSync(
     path.resolve(process.cwd(), config.charactersDataPath),
     'utf-8'
@@ -72,6 +80,9 @@ try {
   const parsed = JSON.parse(data);
   characters = parsed.characters.map((c: any) => ({
     ...c,
+    types: (c.types || [])
+      .map((name: string) => characterTypes.find(t => t.name === name))
+      .filter(Boolean),
     availableAbilities: (c.availableAbilities || []).map((id: string) => moves.get(id)).filter(Boolean),
     abilities: c.abilities
       ? c.abilities.map((id: string) => moves.get(id)).filter(Boolean)

--- a/server/src/models/character.model.ts
+++ b/server/src/models/character.model.ts
@@ -1,4 +1,4 @@
-import { Character, CharacterState } from '../types/game.types';
+import { Character, CharacterState, CharacterType } from '../types/game.types';
 import fs from 'fs';
 import path from 'path';
 import config from '../config/config';
@@ -6,6 +6,7 @@ import config from '../config/config';
 export class CharacterService {
   private characters: Character[] = [];
   private moves: Map<string, any> = new Map();
+  private characterTypes: CharacterType[] = [];
 
   constructor() {
     this.loadCharacters();
@@ -20,6 +21,12 @@ export class CharacterService {
       const parsedMoves = JSON.parse(movesRaw).moves;
       this.moves = new Map(parsedMoves.map((m: any) => [m.id, m]));
 
+      const typesRaw = fs.readFileSync(
+        path.resolve(process.cwd(), config.characterTypesDataPath),
+        'utf-8'
+      );
+      this.characterTypes = JSON.parse(typesRaw);
+
       const charactersData = fs.readFileSync(
         path.resolve(process.cwd(), config.charactersDataPath),
         'utf-8'
@@ -27,6 +34,11 @@ export class CharacterService {
       const parsedData = JSON.parse(charactersData);
       this.characters = parsedData.characters.map((c: any) => ({
         ...c,
+        types: (c.types || [])
+          .map((name: string) =>
+            this.characterTypes.find(t => t.name === name)
+          )
+          .filter(Boolean),
         availableAbilities: (c.availableAbilities || [])
           .map((id: string) => this.moves.get(id))
           .filter(Boolean),

--- a/server/src/types/game.types.ts
+++ b/server/src/types/game.types.ts
@@ -46,6 +46,8 @@ export interface Ability {
   description: string;
   /** Tipo de habilidad: fisico, especial o de estado */
   category: 'physical' | 'special' | 'status';
+  /** Tipo elemental o afinidad de la habilidad */
+  type?: string;
   effects: Effect[];
   /** Ruta a la imagen que representa la habilidad */
   img?: string;


### PR DESCRIPTION
## Summary
- support character types configuration
- add ability type field
- apply 20% bonus when ability matches character type
- show types in Angular components
- assign sample types in data files

## Testing
- `npm --prefix server run build`
- `npm --prefix rolmakelele run build`


------
https://chatgpt.com/codex/tasks/task_e_6850446b052c8327af12dedf179fec5a