### PR TITLE
Improve unique ability display

### DIFF
--- a/rolmakelele/src/app/ability-selector/ability-selector.component.html
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.html
@@ -7,8 +7,9 @@
         width="40"
         height="40"
       />
-      <mat-panel-title class="flex-grow-1 text-nowrap">
+      <mat-panel-title class="flex-grow-1 text-nowrap d-flex align-items-center gap-1">
         {{ ab.name }}
+        <mat-chip color="warn" selected *ngIf="ab.unique">Única</mat-chip>
       </mat-panel-title>
       <mat-panel-description>
         <button

--- a/rolmakelele/src/app/combat/combat.component.html
+++ b/rolmakelele/src/app/combat/combat.component.html
@@ -69,8 +69,9 @@
           class="card-body d-flex flex-column align-items-center justify-content-center text-center"
         >
           <!-- Nombre arriba -->
-          <div class="fw-bold">
+          <div class="fw-bold d-flex align-items-center gap-1">
             {{ ability.name }}
+            <mat-chip color="warn" selected *ngIf="ability.unique">Única</mat-chip>
           </div>
           <!-- Descripción abajo con un pequeño margen -->
           <small class="mt-1"> {{ ability.description }} de energía </small>

--- a/rolmakelele/src/app/combat/combat.component.ts
+++ b/rolmakelele/src/app/combat/combat.component.ts
@@ -7,11 +7,12 @@ import { GameRoom, CharacterState, Ability } from '../models/game.types';
 import { TurnStartedData } from '../models/socket.types';
 import { CharacterBoxComponent } from './character-box/character-box.component';
 import { ChatComponent } from '../chat/chat.component';
+import { MatChipsModule } from '@angular/material/chips';
 
 @Component({
   selector: 'app-combat',
   standalone: true,
-  imports: [CommonModule, CharacterBoxComponent, ChatComponent],
+  imports: [CommonModule, CharacterBoxComponent, ChatComponent, MatChipsModule],
   templateUrl: './combat.component.html',
   styleUrl: './combat.component.scss'
 })

--- a/rolmakelele/src/app/models/game.types.ts
+++ b/rolmakelele/src/app/models/game.types.ts
@@ -44,6 +44,8 @@ export interface Ability {
   description: string;
   /** Tipo de habilidad: fisico, especial o de estado */
   category: 'physical' | 'special' | 'status';
+  /** Indica si la habilidad es exclusiva de un personaje */
+  unique?: boolean;
   effects: Effect[];
   /** Efectos adicionales de la habilidad */
   extraEffects?: Effect[];


### PR DESCRIPTION
## Summary
- add `unique` flag to ability model
- show chip for unique abilities in ability selector
- display unique ability indicator in combat screen

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685056648dc88327b75602c8908eb481