### PR TITLE
Implement buff/debuff levels

### DIFF
--- a/rolmakelele/src/app/combat/character-box/character-box.component.html
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.html
@@ -3,6 +3,9 @@
     <div *ngFor="let key of statKeys" class="mb-1">
       <span [style.color]="getStatColor(key)">
         {{ labels[key] }}: {{ getStatValue(key) }}
+        <ng-container *ngIf="getStatStage(key) !== 0">
+          ({{ getStatStage(key) > 0 ? '+' : '' }}{{ getStatStage(key) }})
+        </ng-container>
       </span>
     </div>
   </div>

--- a/rolmakelele/src/app/combat/character-box/character-box.component.ts
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.ts
@@ -59,6 +59,11 @@ export class CharacterBoxComponent {
     return 'black';
   }
 
+  getStatStage(stat: keyof Stats): number {
+    if (!this.character || !this.character.statStages) return 0;
+    return this.character.statStages[stat] || 0;
+  }
+
   // get CurrentHealth(): number {
 
   // }

--- a/rolmakelele/src/app/models/game.types.ts
+++ b/rolmakelele/src/app/models/game.types.ts
@@ -58,6 +58,8 @@ export interface Character {
   id: string;
   name: string;
   stats: Stats;
+  /** Niveles de modificador para cada estadística (-6 a 6) */
+  statStages?: Stats;
   types: CharacterType[];
   availableAbilities: Ability[];
   abilities: Ability[];
@@ -78,6 +80,7 @@ export interface CharacterType {
 export interface CharacterState extends Character {
   currentHealth: number;
   isAlive: boolean;
+  statStages?: Stats;
 }
 
 // Definición de un jugador

--- a/rolmakelele/src/app/services/game.service.ts
+++ b/rolmakelele/src/app/services/game.service.ts
@@ -257,10 +257,26 @@ export class GameService {
                 (eff.type === 'buff' || eff.type === 'debuff') &&
                 eff.stat
               ) {
+                if (!char.statStages) {
+                  char.statStages = {
+                    speed: 0,
+                    health: 0,
+                    attack: 0,
+                    defense: 0,
+                    specialAttack: 0,
+                    specialDefense: 0,
+                    critical: 0,
+                    evasion: 0,
+                  };
+                }
                 if (!char.currentStats) {
                   char.currentStats = { ...char.stats };
                 }
-                char.currentStats[eff.stat] += eff.value;
+                const current = char.statStages[eff.stat] || 0;
+                const newStage = Math.max(-6, Math.min(6, current + eff.value));
+                char.statStages[eff.stat] = newStage;
+                const base = char.stats[eff.stat];
+                char.currentStats[eff.stat] = Math.max(1, base * (1 + 0.5 * newStage));
               }
             }
           }

--- a/server/data/moves_data.json
+++ b/server/data/moves_data.json
@@ -28,7 +28,7 @@
       ],
       "id": "m002",
       "img": "/public/assets/abilities/fist.png",
-      "extraEffects": [{"type":"buff","target":"self","stat":"attack","value":10,"duration":2}]
+      "extraEffects": [{"type":"buff","target":"self","stat":"attack","value":1,"duration":2}]
 
     },
     {
@@ -39,7 +39,7 @@
         {
           "type": "buff",
           "target": "self",
-          "value": 30,
+          "value": 1,
           "duration": 5,
           "stat": "specialDefense"
         }

--- a/server/src/events/performAction/turnManager.ts
+++ b/server/src/events/performAction/turnManager.ts
@@ -2,6 +2,7 @@ import { Server } from "socket.io";
 import config from "../../config/config";
 import { GameRoom, ActionResult } from "../../types/game.types";
 import { ServerEvents } from "../../types/socket.types";
+import { updateStatStage } from "./utils/effects";
 import { broadcastRoomsList } from '../../utils/roomHelpers';
 
 export function processTurn(
@@ -77,8 +78,8 @@ export function processTurn(
             if (activeEffect.remainingDuration <= 0) {
               expiredEffects.push(i);
               if ((activeEffect.effect.type === 'buff' || activeEffect.effect.type === 'debuff') &&
-                  activeEffect.effect.stat && character.currentStats) {
-                character.currentStats[activeEffect.effect.stat] -= activeEffect.effect.value;
+                  activeEffect.effect.stat) {
+                updateStatStage(character, activeEffect.effect.stat, -activeEffect.effect.value);
               }
             }
           }

--- a/server/src/models/character.model.ts
+++ b/server/src/models/character.model.ts
@@ -77,6 +77,16 @@ export class CharacterService {
         .map(a => ({ ...a })),
       currentHealth: character.stats.health,
       isAlive: true,
+      statStages: {
+        speed: 0,
+        health: 0,
+        attack: 0,
+        defense: 0,
+        specialAttack: 0,
+        specialDefense: 0,
+        critical: 0,
+        evasion: 0
+      },
       currentStats: { ...character.stats },
       activeEffects: []
     };

--- a/server/src/types/game.types.ts
+++ b/server/src/types/game.types.ts
@@ -62,6 +62,8 @@ export interface Character {
   id: string;
   name: string;
   stats: Stats;
+  /** Niveles de modificadores para cada estadística (-6 a 6) */
+  statStages?: Stats;
   types: CharacterType[];
   availableAbilities: Ability[];
   abilities: Ability[];
@@ -82,6 +84,7 @@ export interface CharacterType {
 export interface CharacterState extends Character {
   currentHealth: number;
   isAlive: boolean;
+  statStages?: Stats;
 }
 
 // Definición de un jugador


### PR DESCRIPTION
## Summary
- add stat stage tracking on backend and frontend
- implement stage-aware buff/debuff utilities
- display current stat stages in combat tooltip
- update sample ability data to use stage values

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build`
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685188aa1d648327bc3e58db930528ec