### PR TITLE
Improve buffs and chat tooltip

### DIFF
--- a/rolmakelele/src/app/chat/chat.component.html
+++ b/rolmakelele/src/app/chat/chat.component.html
@@ -11,8 +11,7 @@
       </span>
       <strong>{{ msg.username }}: </strong>
       <span
-        ngxTooltip
-        [content]="msg.tooltip"
+        [ngxTooltip]="msg.tooltip || ''"
         arrow
         [autoUpdate]="true"
         [innerHTML]="formatMessage(msg)"

--- a/rolmakelele/src/app/chat/chat.component.html
+++ b/rolmakelele/src/app/chat/chat.component.html
@@ -10,7 +10,13 @@
         }}
       </span>
       <strong>{{ msg.username }}: </strong>
-      <span [attr.title]="msg.tooltip || null">{{ msg.message }}</span>
+      <span
+        ngxTooltip
+        [content]="msg.tooltip"
+        arrow
+        [autoUpdate]="true"
+        [innerHTML]="formatMessage(msg)"
+      ></span>
     </div>
   </div>
   <form class="input-group mt-2" (ngSubmit)="send()">

--- a/rolmakelele/src/app/chat/chat.component.ts
+++ b/rolmakelele/src/app/chat/chat.component.ts
@@ -3,11 +3,15 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { GameService } from '../services/game.service';
 import { ChatMessageReceivedData } from '../models/socket.types';
+import { NgxTooltip } from '@ngx-popovers/tooltip';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { STATUS_COLORS, STATUS_LABELS } from '../constants/statuses.map';
+import { StatusCondition } from '../models/game.types';
 
 @Component({
   selector: 'app-chat',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, NgxTooltip],
   templateUrl: './chat.component.html',
   styleUrl: './chat.component.scss'
 })
@@ -16,7 +20,21 @@ export class ChatComponent implements OnInit {
   newMessage = '';
   @ViewChild('messagesContainer') messagesContainer!: ElementRef<HTMLDivElement>;
 
-  constructor(private game: GameService) {}
+  readonly statusLabels = STATUS_LABELS;
+  readonly statusColors = STATUS_COLORS;
+
+  constructor(private game: GameService, private sanitizer: DomSanitizer) {}
+
+  formatMessage(msg: ChatMessageReceivedData): SafeHtml {
+    let text = msg.message;
+    for (const key of Object.keys(this.statusLabels) as StatusCondition[]) {
+      const label = this.statusLabels[key];
+      const color = this.statusColors[key];
+      const regex = new RegExp(label, 'gi');
+      text = text.replace(regex, `<span style="color: ${color}">${label}</span>`);
+    }
+    return this.sanitizer.bypassSecurityTrustHtml(text);
+  }
 
   ngOnInit() {
     this.game.chatMessages$.subscribe(m => {

--- a/rolmakelele/src/app/combat/character-box/character-box.component.html
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.html
@@ -10,7 +10,7 @@
     </div>
     <div *ngIf="character?.activeEffects?.length" class="mt-2">
       <strong>Efectos:</strong>
-      <div *ngFor="let eff of character.activeEffects">
+      <div *ngFor="let eff of character?.activeEffects || []">
         <span>
           {{ labels[eff.effect.stat!] }}:
           {{ eff.effect.value > 0 ? '+' : '' }}{{ eff.effect.value }}

--- a/rolmakelele/src/app/combat/character-box/character-box.component.html
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.html
@@ -8,6 +8,16 @@
         </ng-container>
       </span>
     </div>
+    <div *ngIf="character?.activeEffects?.length" class="mt-2">
+      <strong>Efectos:</strong>
+      <div *ngFor="let eff of character.activeEffects">
+        <span>
+          {{ labels[eff.effect.stat!] }}:
+          {{ eff.effect.value > 0 ? '+' : '' }}{{ eff.effect.value }}
+          ({{ formatDuration(eff.remainingDuration) }} turnos)
+        </span>
+      </div>
+    </div>
   </div>
 </ng-template>
 

--- a/rolmakelele/src/app/combat/character-box/character-box.component.ts
+++ b/rolmakelele/src/app/combat/character-box/character-box.component.ts
@@ -34,6 +34,12 @@ export class CharacterBoxComponent {
   readonly statusLabels = STATUS_LABELS;
   readonly statusColors = STATUS_COLORS;
 
+  readonly infinity = '\u221E';
+
+  formatDuration(value: number): string {
+    return isFinite(value) ? value.toString() : this.infinity;
+  }
+
   getStatusColor(status: StatusCondition): string {
     return this.statusColors[status] || '#ccc';
   }

--- a/server/data/moves_data.json
+++ b/server/data/moves_data.json
@@ -28,7 +28,7 @@
       ],
       "id": "m002",
       "img": "/public/assets/abilities/fist.png",
-      "extraEffects": [{"type":"buff","target":"self","stat":"attack","value":1,"duration":2}]
+      "extraEffects": [{"type":"buff","target":"self","stat":"attack","value":1}]
 
     },
     {
@@ -40,7 +40,6 @@
           "type": "buff",
           "target": "self",
           "value": 1,
-          "duration": 5,
           "stat": "specialDefense"
         }
       ],

--- a/server/src/events/performAction/effects.ts
+++ b/server/src/events/performAction/effects.ts
@@ -83,6 +83,12 @@ export function applyAbilityEffects(
         const calcParts = [`Base ${modifiedEffect.value}%`];
         if (attackPortion) calcParts.push(`Atk ${attackPortion.toFixed(2)}`);
         if (reduction) calcParts.push(`- Def ${reduction.toFixed(2)}`);
+        if (
+          ability.category === 'physical' &&
+          sourceCharacter.status === 'burn'
+        ) {
+          calcParts.push('Quemado x0.5');
+        }
         if (isCrit) calcParts.push('x2 Crit');
         const calcString = calcParts.join(' ');
 

--- a/server/src/events/performAction/utils/effects.ts
+++ b/server/src/events/performAction/utils/effects.ts
@@ -26,31 +26,55 @@ export function updateStatStage(character: CharacterState, stat: StatType, delta
   return appliedDelta;
 }
 
-export function applyBuff(character: CharacterState, effect: Effect, result: ActionResult, target: 'source' | 'target') {
+export function applyBuff(
+  character: CharacterState,
+  effect: Effect,
+  result: ActionResult,
+  target: 'source' | 'target'
+) {
   if (effect.stat) {
     const applied = updateStatStage(character, effect.stat, effect.value);
-    if (effect.duration && effect.duration > 0) {
-      if (!character.activeEffects) {
-        character.activeEffects = [];
-      }
-      const storedEffect = { ...effect, value: applied };
-      character.activeEffects.push({ effect: storedEffect, remainingDuration: effect.duration });
+    if (!character.activeEffects) {
+      character.activeEffects = [];
     }
-    result.effects.push({ type: 'buff', target, stat: effect.stat, value: applied, duration: effect.duration });
+    const storedEffect = { ...effect, value: applied };
+    character.activeEffects.push({
+      effect: storedEffect,
+      remainingDuration: Number.POSITIVE_INFINITY
+    });
+    result.effects.push({
+      type: 'buff',
+      target,
+      stat: effect.stat,
+      value: applied,
+      duration: Number.POSITIVE_INFINITY
+    });
   }
 }
 
-export function applyDebuff(character: CharacterState, effect: Effect, result: ActionResult, target: 'source' | 'target') {
+export function applyDebuff(
+  character: CharacterState,
+  effect: Effect,
+  result: ActionResult,
+  target: 'source' | 'target'
+) {
   if (effect.stat) {
     const applied = updateStatStage(character, effect.stat, effect.value);
-    if (effect.duration && effect.duration > 0) {
-      if (!character.activeEffects) {
-        character.activeEffects = [];
-      }
-      const storedEffect = { ...effect, value: applied };
-      character.activeEffects.push({ effect: storedEffect, remainingDuration: effect.duration });
+    if (!character.activeEffects) {
+      character.activeEffects = [];
     }
-    result.effects.push({ type: 'debuff', target, stat: effect.stat, value: applied, duration: effect.duration });
+    const storedEffect = { ...effect, value: applied };
+    character.activeEffects.push({
+      effect: storedEffect,
+      remainingDuration: Number.POSITIVE_INFINITY
+    });
+    result.effects.push({
+      type: 'debuff',
+      target,
+      stat: effect.stat,
+      value: applied,
+      duration: Number.POSITIVE_INFINITY
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- enhance chat tooltips using `NgxTooltip`
- color status words in chat messages
- show active effects with remaining turns in character tooltip
- set buffs and debuffs to last indefinitely
- remove `duration` from move data

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in `rolmakelele` (fails to run `ng test`)

------
https://chatgpt.com/codex/tasks/task_e_68519d7c127883278de7f69b6c33d74d