### PR TITLE
Round damage calculations

### DIFF
--- a/server/src/events/performAction/effects.ts
+++ b/server/src/events/performAction/effects.ts
@@ -81,8 +81,8 @@ export function applyAbilityEffects(
         actionResult.effects.push({ type: 'damage', target: 'target', value: amount });
 
         const calcParts = [`Base ${modifiedEffect.value}%`];
-        if (attackPortion) calcParts.push(`Atk ${attackPortion.toFixed(2)}`);
-        if (reduction) calcParts.push(`- Def ${reduction.toFixed(2)}`);
+        if (attackPortion) calcParts.push(`Atk ${Math.round(attackPortion)}`);
+        if (reduction) calcParts.push(`- Def ${Math.round(reduction)}`);
         if (
           ability.category === 'physical' &&
           sourceCharacter.status === 'burn'
@@ -94,7 +94,7 @@ export function applyAbilityEffects(
 
         io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
           username: 'Sistema',
-          message: `${sourcePlayer.username} - ${sourceCharacter.name} causó ${amount.toFixed(2)} de daño a ${targetPlayer.username} - ${targetCharacter.name}`,
+          message: `${sourcePlayer.username} - ${sourceCharacter.name} causó ${amount} de daño a ${targetPlayer.username} - ${targetCharacter.name}`,
           tooltip: calcString,
           timestamp: new Date(),
           isSpectator: false,

--- a/server/src/events/performAction/turnManager.ts
+++ b/server/src/events/performAction/turnManager.ts
@@ -75,13 +75,13 @@ export function processTurn(
     if (activeChar && activeChar.status) {
       activeChar.statusTurns = (activeChar.statusTurns || 0) + 1;
       if (activeChar.status === 'burn') {
-        const dmg = activeChar.stats.health * 0.125;
+        const dmg = Math.round(activeChar.stats.health * 0.125);
         activeChar.currentHealth = Math.max(0, activeChar.currentHealth - dmg);
         if (activeChar.currentHealth === 0) activeChar.isAlive = false;
         startEffects.push({ type: 'damage', target: 'source', value: dmg });
         io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
           username: 'Sistema',
-          message: `${activePlayer?.username} - ${activeChar.name} sufre ${dmg.toFixed(2)} de daño por quemadura`,
+          message: `${activePlayer?.username} - ${activeChar.name} sufre ${dmg} de daño por quemadura`,
           timestamp: new Date(),
           isSpectator: false,
           isSystem: true
@@ -100,13 +100,13 @@ export function processTurn(
       } else if (activeChar.status === 'drunk') {
         const selfHit = Math.random() < 1 / 3;
         if (selfHit) {
-          const dmg = activeChar.stats.health * 0.0625;
+          const dmg = Math.round(activeChar.stats.health * 0.0625);
           activeChar.currentHealth = Math.max(0, activeChar.currentHealth - dmg);
           if (activeChar.currentHealth === 0) activeChar.isAlive = false;
           startEffects.push({ type: 'damage', target: 'source', value: dmg });
           io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
             username: 'Sistema',
-            message: `${activePlayer?.username} - ${activeChar.name} se golpeó a sí mismo y perdió ${dmg.toFixed(2)} de vida`,
+            message: `${activePlayer?.username} - ${activeChar.name} se golpeó a sí mismo y perdió ${dmg} de vida`,
             timestamp: new Date(),
             isSpectator: false,
             isSystem: true

--- a/server/src/events/performAction/utils/damage.ts
+++ b/server/src/events/performAction/utils/damage.ts
@@ -41,5 +41,5 @@ export function calculateDamage(
     damage *= 2;
   }
 
-  return { amount: damage, attackPortion, reduction, isCrit };
+  return { amount: Math.round(damage), attackPortion, reduction, isCrit };
 }


### PR DESCRIPTION
## Summary
- round damage results so health stays integer
- adjust burn/drunk messages to show integer damage
- display ability damage calculations using integers

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in `rolmakelele` (fails: `ng` not found)

------
https://chatgpt.com/codex/tasks/task_e_6851a35bc21083279e4e71848f19407b