### PR TITLE
Update abilities and character type colors

### DIFF
--- a/rolmakelele/public/character.types.json
+++ b/rolmakelele/public/character.types.json
@@ -2,5 +2,9 @@
     {"id": "t001", "name":"Programador", "color":"#FF5733"},
     {"id": "t002", "name":"Techno", "color":"#33FF57"},
     {"id": "t003", "name":"Musico", "color":"#3357FF"},
-    {"id": "t004", "name":"Friki", "color":"#FF33A1"}
+    {"id": "t004", "name":"Friki", "color":"#FF33A1"},
+    {"id": "t005", "name":"Ingeniero", "color":"#FFBD33"},
+    {"id": "t006", "name":"Moro", "color":"#33FFF7"},
+    {"id": "t006", "name":"Deportista", "color":"#FF3333"},
+    {"id": "t007", "name":"Barman", "color":"#9B59B6"}
 ]

--- a/rolmakelele/public/character.types.json
+++ b/rolmakelele/public/character.types.json
@@ -5,6 +5,6 @@
     {"id": "t004", "name":"Friki", "color":"#FF33A1"},
     {"id": "t005", "name":"Ingeniero", "color":"#FFBD33"},
     {"id": "t006", "name":"Moro", "color":"#33FFF7"},
-    {"id": "t006", "name":"Deportista", "color":"#FF3333"},
-    {"id": "t007", "name":"Barman", "color":"#9B59B6"}
+    {"id": "t007", "name":"Deportista", "color":"#FF3333"},
+    {"id": "t008", "name":"Barman", "color":"#9B59B6"}
 ]

--- a/rolmakelele/src/app/ability-selector/ability-selector.component.html
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.html
@@ -36,28 +36,12 @@
       {{ ab.description }} <small class="text-muted">({{ ab.category }})</small>
     </p>
     <ul>
-      <li *ngFor="let effect of ab.effects">
-        <span>{{ effect.type }} sobre {{ effect.target }}</span>
-        <span *ngIf="effect.stat"> ({{ effect.stat }})</span>
-        <span> : {{ effect.value }}</span>
-        <span *ngIf="effect.duration"> ({{ effect.duration }} turnos)</span>
-        <span *ngIf="effect.ignoreDefense">
-          (ignora defensa {{ effect.ignoreDefense * 100 }}%)
-        </span>
-      </li>
+      <li *ngFor="let effect of ab.effects">{{ formatEffect(effect) }}</li>
     </ul>
     <div *ngIf="ab.extraEffects?.length">
       <strong>Efectos extra:</strong>
       <ul>
-        <li *ngFor="let effect of ab.extraEffects">
-          <span>{{ effect.type }} sobre {{ effect.target }}</span>
-          <span *ngIf="effect.stat"> ({{ effect.stat }})</span>
-          <span> : {{ effect.value }}</span>
-          <span *ngIf="effect.duration"> ({{ effect.duration }} turnos)</span>
-          <span *ngIf="effect.ignoreDefense">
-            (ignora defensa {{ effect.ignoreDefense * 100 }}%)
-          </span>
-        </li>
+        <li *ngFor="let effect of ab.extraEffects">{{ formatEffect(effect) }}</li>
       </ul>
     </div>
   </mat-expansion-panel>

--- a/rolmakelele/src/app/ability-selector/ability-selector.component.html
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.html
@@ -15,8 +15,8 @@
         height="40"
       />
       <mat-panel-title
-        class="flex-grow-1 d-flex align-items-center gap-1 text-truncate"
-        style="min-width: 0"
+        class="flex-grow-1 d-flex align-items-center gap-1"
+        style="min-width: 0; white-space: normal; word-break: break-word;"
       >
         {{ ab.name }}
         <!-- <mat-chip color="warn" selected *ngIf="ab.unique">Única</mat-chip> -->

--- a/rolmakelele/src/app/ability-selector/ability-selector.component.html
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.html
@@ -23,6 +23,13 @@
         @if (ab.unique) {
           <app-unique-tag></app-unique-tag>
         }
+        <mat-chip
+          *ngIf="ab.type"
+          selected
+          [style.backgroundColor]="types.getColor(ab.type)"
+        >
+          {{ ab.type }}
+        </mat-chip>
       </mat-panel-title>
     </mat-expansion-panel-header>
     <p>

--- a/rolmakelele/src/app/ability-selector/ability-selector.component.html
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.html
@@ -30,10 +30,16 @@
         >
           {{ ab.type }}
         </mat-chip>
+        <mat-chip
+          selected
+          [style.backgroundColor]="getCategoryColor(ab.category)"
+        >
+          {{ getCategoryLabel(ab.category) }}
+        </mat-chip>
       </mat-panel-title>
     </mat-expansion-panel-header>
     <p>
-      {{ ab.description }} <small class="text-muted">({{ ab.category }})</small>
+      {{ ab.description }}
     </p>
     <ul>
       <li *ngFor="let effect of ab.effects">{{ formatEffect(effect) }}</li>

--- a/rolmakelele/src/app/ability-selector/ability-selector.component.ts
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.ts
@@ -1,12 +1,14 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Ability, Character } from '../models/game.types';
+import { Ability, Character, Effect, EffectTarget } from '../models/game.types';
 import { GameService } from '../services/game.service';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatChipsModule } from '@angular/material/chips';
 import { environment } from '../../environments/environment';
 import { TypeService } from '../services/type.service';
-import { UniqueTagComponent } from "../unique-tag/unique-tag.component";
+import { UniqueTagComponent } from '../unique-tag/unique-tag.component';
+import { LABELS_MAP } from '../constants/stats.map';
+import { STATUS_LABELS } from '../constants/statuses.map';
 
 @Component({
   selector: 'app-ability-selector',
@@ -38,5 +40,47 @@ export class AbilitySelectorComponent implements OnInit {
       this.selectedIds.push(id);
     }
     this.selectionChange.emit([...this.selectedIds]);
+  }
+
+  formatEffect(effect: Effect): string {
+    const targets: Record<EffectTarget, string> = {
+      self: 'a sí mismo',
+      opponent: 'al enemigo',
+      allies: 'a los aliados',
+    };
+
+    let text = '';
+    switch (effect.type) {
+      case 'damage':
+        text = `Daño ${effect.value}`;
+        if (effect.ignoreDefense) {
+          text += ` (ignora defensa ${effect.ignoreDefense * 100}%)`;
+        }
+        break;
+      case 'heal':
+        text = `Cura ${effect.value}`;
+        break;
+      case 'buff':
+        const buffStat = effect.stat ? LABELS_MAP[effect.stat] || effect.stat : '';
+        text = `Aumenta ${buffStat} +${effect.value}`;
+        break;
+      case 'debuff':
+        const debuffStat = effect.stat ? LABELS_MAP[effect.stat] || effect.stat : '';
+        text = `Reduce ${debuffStat} ${effect.value}`;
+        break;
+      case 'status':
+        const status = effect.status ? STATUS_LABELS[effect.status] || effect.status : '';
+        text = `Aplica estado ${status}`;
+        if (effect.statusChance !== undefined) {
+          text += ` (${effect.statusChance * 100}%)`;
+        }
+        break;
+    }
+
+    if (effect.duration) {
+      text += ` durante ${effect.duration} turnos`;
+    }
+
+    return `${targets[effect.target]}: ${text}`;
   }
 }

--- a/rolmakelele/src/app/ability-selector/ability-selector.component.ts
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.ts
@@ -85,7 +85,7 @@ export class AbilitySelectorComponent implements OnInit {
         const status = effect.status ? STATUS_LABELS[effect.status] || effect.status : '';
         text = `Aplica estado ${status}`;
         if (effect.statusChance !== undefined) {
-          text += ` (${effect.statusChance * 100}%)`;
+          text += ` (${Math.round(effect.statusChance * 100)}%)`;
         }
         break;
       case 'cure':
@@ -99,7 +99,8 @@ export class AbilitySelectorComponent implements OnInit {
     }
 
     if (effect.chance !== undefined && effect.chance < 1) {
-      text += ` (${effect.chance * 100}%)`;
+      const perc = Math.round(effect.chance * 100);
+      text += ` (${perc}%)`;
     }
 
     return `${targets[effect.target]}: ${text}`;

--- a/rolmakelele/src/app/ability-selector/ability-selector.component.ts
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.ts
@@ -67,7 +67,11 @@ export class AbilitySelectorComponent implements OnInit {
         }
         break;
       case 'heal':
-        text = `Cura ${effect.value}`;
+        if (effect.healLost) {
+          text = `Cura vida perdida + ${effect.value}`;
+        } else {
+          text = `Cura ${effect.value}`;
+        }
         break;
       case 'buff':
         const buffStat = effect.stat ? LABELS_MAP[effect.stat] || effect.stat : '';
@@ -84,10 +88,18 @@ export class AbilitySelectorComponent implements OnInit {
           text += ` (${effect.statusChance * 100}%)`;
         }
         break;
+      case 'cure':
+        const cureStatus = effect.status ? STATUS_LABELS[effect.status] || effect.status : 'alterado';
+        text = `Elimina estado ${cureStatus}`;
+        break;
     }
 
     if (effect.duration) {
       text += ` durante ${effect.duration} turnos`;
+    }
+
+    if (effect.chance !== undefined && effect.chance < 1) {
+      text += ` (${effect.chance * 100}%)`;
     }
 
     return `${targets[effect.target]}: ${text}`;

--- a/rolmakelele/src/app/ability-selector/ability-selector.component.ts
+++ b/rolmakelele/src/app/ability-selector/ability-selector.component.ts
@@ -9,6 +9,7 @@ import { TypeService } from '../services/type.service';
 import { UniqueTagComponent } from '../unique-tag/unique-tag.component';
 import { LABELS_MAP } from '../constants/stats.map';
 import { STATUS_LABELS } from '../constants/statuses.map';
+import { CATEGORY_LABELS, CATEGORY_COLORS } from '../constants/categories.map';
 
 @Component({
   selector: 'app-ability-selector',
@@ -25,6 +26,14 @@ export class AbilitySelectorComponent implements OnInit {
   readonly serverUrl = environment.apiBase;
 
   constructor(private game: GameService, public types: TypeService) {}
+
+  getCategoryLabel(cat: Ability['category']): string {
+    return CATEGORY_LABELS[cat];
+  }
+
+  getCategoryColor(cat: Ability['category']): string {
+    return CATEGORY_COLORS[cat];
+  }
 
   ngOnInit() {
     this.game

--- a/rolmakelele/src/app/constants/categories.map.ts
+++ b/rolmakelele/src/app/constants/categories.map.ts
@@ -1,0 +1,11 @@
+export const CATEGORY_LABELS: Record<'physical' | 'special' | 'status', string> = {
+  physical: 'Físico',
+  special: 'Especial',
+  status: 'Estado',
+};
+
+export const CATEGORY_COLORS: Record<'physical' | 'special' | 'status', string> = {
+  physical: '#f06292',
+  special: '#64b5f6',
+  status: '#81c784',
+};

--- a/rolmakelele/src/app/models/game.types.ts
+++ b/rolmakelele/src/app/models/game.types.ts
@@ -16,7 +16,7 @@ export interface Stats {
 
 // Tipos de efectos para las habilidades
 export type EffectType = 'damage' | 'heal' | 'buff' | 'debuff' | 'status';
-export type EffectTarget = 'self' | 'opponent';
+export type EffectTarget = 'self' | 'opponent' | 'allies';
 export type StatType =
   | 'speed'
   | 'health'

--- a/rolmakelele/src/app/models/game.types.ts
+++ b/rolmakelele/src/app/models/game.types.ts
@@ -49,6 +49,8 @@ export interface Ability {
   description: string;
   /** Tipo de habilidad: fisico, especial o de estado */
   category: 'physical' | 'special' | 'status';
+  /** Tipo elemental o afinidad de la habilidad */
+  type?: string;
   /** Indica si la habilidad es exclusiva de un personaje */
   unique?: boolean;
   effects: Effect[];

--- a/rolmakelele/src/app/models/game.types.ts
+++ b/rolmakelele/src/app/models/game.types.ts
@@ -15,7 +15,13 @@ export interface Stats {
 }
 
 // Tipos de efectos para las habilidades
-export type EffectType = 'damage' | 'heal' | 'buff' | 'debuff' | 'status';
+export type EffectType =
+  | 'damage'
+  | 'heal'
+  | 'buff'
+  | 'debuff'
+  | 'status'
+  | 'cure';
 export type EffectTarget = 'self' | 'opponent' | 'allies';
 export type StatType =
   | 'speed'
@@ -40,6 +46,10 @@ export interface Effect {
   status?: StatusCondition | null;
   /** Probability to apply the status (0-1) */
   statusChance?: number;
+  /** Probability to apply the effect (0-1) */
+  chance?: number;
+  /** If true, heals the lost HP in addition to value */
+  healLost?: boolean;
 }
 
 // Definición de una habilidad

--- a/server/data/character.types.json
+++ b/server/data/character.types.json
@@ -3,8 +3,8 @@
     {"id": "t002", "name":"Techno", "color":"#33FF57"},
     {"id": "t003", "name":"Musico", "color":"#3357FF"},
     {"id": "t004", "name":"Friki", "color":"#FF33A1"},
-    {"id": "t005", "name":"Ingeniero", "color":"#FF33A1"},
-    {"id": "t006", "name":"Moro", "color":"#FF33A1"},
-    {"id": "t006", "name":"Deportista", "color":"#FF33A1"}
-    ,{"id": "t007", "name":"Barman", "color":"#9B59B6"}
+    {"id": "t005", "name":"Ingeniero", "color":"#FFBD33"},
+    {"id": "t006", "name":"Moro", "color":"#33FFF7"},
+    {"id": "t006", "name":"Deportista", "color":"#FF3333"},
+    {"id": "t007", "name":"Barman", "color":"#9B59B6"}
 ]

--- a/server/data/character.types.json
+++ b/server/data/character.types.json
@@ -5,6 +5,6 @@
     {"id": "t004", "name":"Friki", "color":"#FF33A1"},
     {"id": "t005", "name":"Ingeniero", "color":"#FFBD33"},
     {"id": "t006", "name":"Moro", "color":"#33FFF7"},
-    {"id": "t006", "name":"Deportista", "color":"#FF3333"},
-    {"id": "t007", "name":"Barman", "color":"#9B59B6"}
+    {"id": "t007", "name":"Deportista", "color":"#FF3333"},
+    {"id": "t008", "name":"Barman", "color":"#9B59B6"}
 ]

--- a/server/data/moves_data.json
+++ b/server/data/moves_data.json
@@ -35,13 +35,15 @@
       "name": "Trago de cerveza",
       "description": "Se toma una cerveza para aumentar su defensa especial",
       "category": "status",
+      "type": "Barman",
       "effects": [
         {
           "type": "buff",
           "target": "self",
           "value": 1,
           "stat": "specialDefense"
-        }
+        },
+        { "type": "heal", "target": "self", "value": 15 }
       ],
       "id": "m003",
       "img": "/public/assets/abilities/drink.png"
@@ -56,6 +58,9 @@
       "effects": [
         { "type": "buff", "target": "self", "stat": "speed", "value": 1 },
         { "type": "buff", "target": "self", "stat": "specialAttack", "value": 1 }
+      ],
+      "extraEffects": [
+        { "type": "buff", "target": "allies", "stat": "speed", "value": 1 }
       ],
       "id": "m004",
       "img": "/public/assets/abilities/drink.png"
@@ -208,13 +213,13 @@
     {
       "name": "Un segarro amigo",
       "description": "Baja la defensa especial e inflige daño",
-      "category": "status",
+      "category": "physical",
       "type": "Moro",
       "effects": [
         { "type": "debuff", "target": "opponent", "stat": "specialDefense", "value": -1 }
       ],
       "extraEffects": [
-        { "type": "damage", "target": "opponent", "value": 20 }
+        { "type": "damage", "target": "opponent", "value": 15 }
       ],
       "id": "m014",
       "img": "/public/assets/abilities/fist.png"

--- a/server/data/moves_data.json
+++ b/server/data/moves_data.json
@@ -67,11 +67,13 @@
     },
     {
       "name": "Tragito coctel",
-      "description": "Aumenta su ataque especial perdiendo algo de vida",
+      "description": "Aumenta su ataque especial y puede curar o eliminar la borrachera",
       "category": "status",
       "type": "Barman",
       "effects": [
-        { "type": "buff", "target": "self", "stat": "specialAttack", "value": 1 }
+        { "type": "buff", "target": "self", "stat": "specialAttack", "value": 1 },
+        { "type": "heal", "target": "self", "value": 10, "chance": 0.65, "healLost": true },
+        { "type": "cure", "target": "self", "status": "drunk", "value": 0, "chance": 0.35 }
       ],
       "id": "m005",
       "img": "/public/assets/abilities/drink.png"

--- a/server/data/moves_data.json
+++ b/server/data/moves_data.json
@@ -42,38 +42,36 @@
           "target": "self",
           "value": 1,
           "stat": "specialDefense"
-        },
-        { "type": "heal", "target": "self", "value": 15 }
+        }
       ],
       "id": "m003",
-      "img": "/public/assets/abilities/drink.png"
+      "img": "/public/assets/abilities/drink.png",
+      "extraEffects": [{ "type": "heal", "target": "self", "value": 15 }]
+
     },
    
     {
       "name": "Agita la coctelera",
       "description": "Aumenta su velocidad y ataque especial",
       "category": "status",
-      "type": "Barman",
       "unique": true,
       "effects": [
         { "type": "buff", "target": "self", "stat": "speed", "value": 1 },
-        { "type": "buff", "target": "self", "stat": "specialAttack", "value": 1 }
+        { "type": "buff", "target": "self", "stat": "specialAttack", "value": 1 },
+       { "type": "buff", "target": "allies", "stat": "speed", "value": 1 }
       ],
-      "extraEffects": [
-        { "type": "buff", "target": "allies", "stat": "speed", "value": 1 }
-      ],
+      
       "id": "m004",
       "img": "/public/assets/abilities/drink.png"
     },
     {
       "name": "Tragito coctel",
-      "description": "Aumenta su ataque especial y puede curar o eliminar la borrachera",
+      "description": "Aumenta su ataque especial perdiendo algo de vida",
       "category": "status",
       "type": "Barman",
       "effects": [
-        { "type": "buff", "target": "self", "stat": "specialAttack", "value": 1 },
-        { "type": "heal", "target": "self", "value": 10, "chance": 0.65, "healLost": true },
-        { "type": "cure", "target": "self", "status": "drunk", "value": 0, "chance": 0.35 }
+        { "type": "buff", "target": "self", "stat": "specialAttack", "value": 2 },
+        { "type": "damage", "target": "self", "value": 10 }
       ],
       "id": "m005",
       "img": "/public/assets/abilities/drink.png"
@@ -160,7 +158,7 @@
       "unique": true,
       "effects": [
         { "type": "damage", "target": "opponent", "value": 45 },
-        { "type": "buff", "target": "self", "stat": "specialAttack", "value": 1 }
+        { "type": "buff", "target": "self", "stat": "specialAttack", "value": 2 }
       ],
       "id": "m010",
       "img": "/public/assets/abilities/insult.png"
@@ -198,7 +196,6 @@
       "name": "Achio piho",
       "description": "Hace retroceder al enemigo",
       "category": "status",
-      "type": "Moro",
       "unique": true,
       "effects": [
         {

--- a/server/src/events/performAction/utils/effects.ts
+++ b/server/src/events/performAction/utils/effects.ts
@@ -78,10 +78,32 @@ export function applyDebuff(
   }
 }
 
-export function applyHeal(character: CharacterState, effect: Effect, result: ActionResult, target: 'source' | 'target') {
-  const healAmount = effect.value;
-  character.currentHealth = Math.min(character.currentHealth + healAmount, character.stats.health);
+export function applyHeal(
+  character: CharacterState,
+  effect: Effect,
+  result: ActionResult,
+  target: 'source' | 'target'
+) {
+  let healAmount = effect.value;
+  if (effect.healLost) {
+    healAmount += character.stats.health - character.currentHealth;
+  }
+  character.currentHealth = Math.min(
+    character.currentHealth + healAmount,
+    character.stats.health
+  );
   result.effects.push({ type: 'heal', target, value: healAmount });
+}
+
+export function applyCure(
+  character: CharacterState,
+  status: StatusCondition | null,
+  result: ActionResult,
+  target: 'source' | 'target'
+) {
+  if (!status || character.status === status) {
+    removeStatus(character, result.effects, target);
+  }
 }
 
 export function applyStatus(character: CharacterState, status: StatusCondition, result: ActionResult, target: 'source' | 'target') {

--- a/server/src/types/game.types.ts
+++ b/server/src/types/game.types.ts
@@ -18,7 +18,7 @@ export interface Stats {
 
 // Tipos de efectos para las habilidades
 export type EffectType = 'damage' | 'heal' | 'buff' | 'debuff' | 'status';
-export type EffectTarget = 'self' | 'opponent';
+export type EffectTarget = 'self' | 'opponent' | 'allies';
 export type StatType =
   | 'speed'
   | 'health'

--- a/server/src/types/game.types.ts
+++ b/server/src/types/game.types.ts
@@ -17,7 +17,7 @@ export interface Stats {
 }
 
 // Tipos de efectos para las habilidades
-export type EffectType = 'damage' | 'heal' | 'buff' | 'debuff' | 'status';
+export type EffectType = 'damage' | 'heal' | 'buff' | 'debuff' | 'status' | 'cure';
 export type EffectTarget = 'self' | 'opponent' | 'allies';
 export type StatType =
   | 'speed'
@@ -42,6 +42,10 @@ export interface Effect {
   status?: StatusCondition | null;
   /** Probability to apply the status (0-1) */
   statusChance?: number;
+  /** Probability to apply the effect (0-1) */
+  chance?: number;
+  /** If true, heals the HP lost in addition to value */
+  healLost?: boolean;
 }
 
 // Definición de una habilidad


### PR DESCRIPTION
## Summary
- ensure unique colors in `character.types.json`
- mark ability `m003` as Barman and add healing effect
- let `m004` buff allies' speed
- tweak `m014` to physical type and deal 15 damage
- support new `allies` target in type definitions

## Testing
- `npm test` in `server`
- `npm test` in `rolmakelele` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ae6ce13083278fcfc74dfb0045ec