### PR TITLE
Improve server modularity

### DIFF
--- a/server/src/events/disconnect.ts
+++ b/server/src/events/disconnect.ts
@@ -2,6 +2,7 @@ import { Server, Socket } from "socket.io";
 import { GameRoom } from "../types/game.types";
 import { ServerEvents } from "../types/socket.types";
 import { broadcastRoomsList } from '../utils/roomHelpers';
+import { sendSystemMessage } from '../utils/messages';
 
 export function registerDisconnect(
   io: Server,
@@ -38,13 +39,11 @@ export function registerDisconnect(
                 winnerUsername: winner.username,
                 reason: 'player_disconnected_timeout'
               });
-              io.to(roomId).emit(ServerEvents.CHAT_MESSAGE, {
-                username: 'Sistema',
-                message: `El juego ha terminado. Ganador: ${winner.username}`,
-                timestamp: new Date(),
-                isSpectator: false,
-                isSystem: true
-              });
+              sendSystemMessage(
+                io,
+                roomId,
+                `El juego ha terminado. Ganador: ${winner.username}`
+              );
               rooms.delete(roomId);
             }
             broadcastRoomsList(io, rooms);
@@ -54,13 +53,7 @@ export function registerDisconnect(
         disconnectTimers.set(key, timer);
 
         io.to(roomId).emit(ServerEvents.ROOM_UPDATED, { room });
-        io.to(roomId).emit(ServerEvents.CHAT_MESSAGE, {
-          username: 'Sistema',
-          message: `${player.username} se ha desconectado`,
-          timestamp: new Date(),
-          isSpectator: false,
-          isSystem: true
-        });
+        sendSystemMessage(io, roomId, `${player.username} se ha desconectado`);
       }
       
       // Buscar como espectador
@@ -78,13 +71,7 @@ export function registerDisconnect(
           io.to(roomId).emit(ServerEvents.ROOM_UPDATED, { room });
           
           // Enviar mensaje de chat
-          io.to(roomId).emit(ServerEvents.CHAT_MESSAGE, {
-            username: 'Sistema',
-            message: `Un espectador se ha desconectado`,
-            timestamp: new Date(),
-            isSpectator: true,
-            isSystem: true
-          });
+          sendSystemMessage(io, roomId, `Un espectador se ha desconectado`, { isSpectator: true });
         }
       }
     }

--- a/server/src/events/joinAsSpectator.ts
+++ b/server/src/events/joinAsSpectator.ts
@@ -1,6 +1,7 @@
 import { Server, Socket } from 'socket.io';
 import { GameRoom } from '../types/game.types';
 import { ClientEvents, ServerEvents, JoinRoomData } from '../types/socket.types';
+import { sendSystemMessage } from '../utils/messages';
 
 export function registerJoinAsSpectator(
   io: Server,
@@ -32,12 +33,6 @@ export function registerJoinAsSpectator(
 
     io.to(data.roomId).emit(ServerEvents.ROOM_UPDATED, { room });
 
-    io.to(data.roomId).emit(ServerEvents.CHAT_MESSAGE, {
-      username: 'Sistema',
-      message: `${data.username} se ha unido como espectador`,
-      timestamp: new Date(),
-      isSpectator: true,
-      isSystem: true
-    });
+    sendSystemMessage(io, data.roomId, `${data.username} se ha unido como espectador`, { isSpectator: true });
   });
 }

--- a/server/src/events/joinRoom.ts
+++ b/server/src/events/joinRoom.ts
@@ -3,6 +3,7 @@ import config from '../config/config';
 import { GameRoom, Player } from '../types/game.types';
 import { ClientEvents, ServerEvents, JoinRoomData } from '../types/socket.types';
 import { broadcastRoomsList } from '../utils/roomHelpers';
+import { sendSystemMessage } from '../utils/messages';
 
 export function registerJoinRoom(
   io: Server,
@@ -49,13 +50,7 @@ export function registerJoinRoom(
         socket.join(data.roomId);
         socket.emit(ServerEvents.ROOM_JOINED, { room });
         io.to(data.roomId).emit(ServerEvents.ROOM_UPDATED, { room });
-        io.to(data.roomId).emit(ServerEvents.CHAT_MESSAGE, {
-          username: 'Sistema',
-          message: `${data.username} se ha reconectado`,
-          timestamp: new Date(),
-          isSpectator: false,
-          isSystem: true
-        });
+        sendSystemMessage(io, data.roomId, `${data.username} se ha reconectado`);
         return;
       } else {
         socket.emit(ServerEvents.ERROR, {

--- a/server/src/events/leaveRoom.ts
+++ b/server/src/events/leaveRoom.ts
@@ -2,6 +2,7 @@ import { Server, Socket } from "socket.io";
 import { GameRoom } from "../types/game.types";
 import { ClientEvents, ServerEvents } from "../types/socket.types";
 import { broadcastRoomsList } from '../utils/roomHelpers';
+import { sendSystemMessage } from '../utils/messages';
 
 export function registerLeaveRoom(io: Server, socket: Socket, rooms: Map<string, GameRoom>) {
 
@@ -33,13 +34,7 @@ export function registerLeaveRoom(io: Server, socket: Socket, rooms: Map<string,
               winnerUsername: winner.username,
               reason: 'player_left'
             });
-            io.to(roomId).emit(ServerEvents.CHAT_MESSAGE, {
-              username: 'Sistema',
-              message: `El juego ha terminado. Ganador: ${winner.username}`,
-              timestamp: new Date(),
-              isSpectator: false,
-              isSystem: true
-            });
+            sendSystemMessage(io, roomId, `El juego ha terminado. Ganador: ${winner.username}`);
             rooms.delete(roomId);
           }
         }else if (room.status === 'character_selection') {

--- a/server/src/events/performAction.ts
+++ b/server/src/events/performAction.ts
@@ -4,6 +4,7 @@ import { ClientEvents, ServerEvents, PerformActionData } from "../types/socket.t
 import { validateAction } from './performAction/validation';
 import { applyAbilityEffects } from './performAction/effects';
 import { processTurn } from './performAction/turnManager';
+import { sendSystemMessage } from '../utils/messages';
 
 export function registerPerformAction(io: Server, socket: Socket, rooms: Map<string, GameRoom>) {
 
@@ -40,13 +41,11 @@ export function registerPerformAction(io: Server, socket: Socket, rooms: Map<str
       actionResult
     );
 
-    io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
-      username: 'Sistema',
-      message: `${sourcePlayer.username} - ${sourceCharacter.name} usó ${ability.name} sobre ${targetPlayer.username} - ${targetCharacter.name}`,
-      timestamp: new Date(),
-      isSpectator: false,
-      isSystem: true
-    });
+    sendSystemMessage(
+      io,
+      playerRoom.id,
+      `${sourcePlayer.username} - ${sourceCharacter.name} usó ${ability.name} sobre ${targetPlayer.username} - ${targetCharacter.name}`
+    );
 
     processTurn(io, rooms, playerRoom, actionResult);
   });

--- a/server/src/events/performAction/effects.ts
+++ b/server/src/events/performAction/effects.ts
@@ -8,6 +8,7 @@ import {
   ActionResult
 } from "../../types/game.types";
 import { ServerEvents } from "../../types/socket.types";
+import { sendSystemMessage } from '../../utils/messages';
 import {
   applyBuff,
   applyDebuff,
@@ -60,13 +61,11 @@ export function applyAbilityEffects(
         const evasionChance = targetCharacter.currentStats?.evasion || 0;
         if (Math.random() < evasionChance / 100) {
           actionResult.effects.push({ type: 'damage', target: 'target', value: 0 });
-          io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
-            username: 'Sistema',
-            message: `${targetPlayer.username} - ${targetCharacter.name} esquivó el ataque`,
-            timestamp: new Date(),
-            isSpectator: false,
-            isSystem: true
-          });
+          sendSystemMessage(
+            io,
+            playerRoom.id,
+            `${targetPlayer.username} - ${targetCharacter.name} esquivó el ataque`
+          );
           return;
         }
 
@@ -99,14 +98,12 @@ export function applyAbilityEffects(
         if (isCrit) calcParts.push('x2 Crit');
         const calcString = calcParts.join(' ');
 
-        io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
-          username: 'Sistema',
-          message: `${sourcePlayer.username} - ${sourceCharacter.name} causó ${amount} de daño a ${targetPlayer.username} - ${targetCharacter.name}`,
-          tooltip: calcString,
-          timestamp: new Date(),
-          isSpectator: false,
-          isSystem: true
-        });
+        sendSystemMessage(
+          io,
+          playerRoom.id,
+          `${sourcePlayer.username} - ${sourceCharacter.name} causó ${amount} de daño a ${targetPlayer.username} - ${targetCharacter.name}`,
+          { tooltip: calcString }
+        );
       } else if (effect.type === 'debuff') {
         applyDebuff(targetCharacter, modifiedEffect, actionResult, 'target');
       } else if (effect.type === 'heal') {

--- a/server/src/events/performAction/turnManager.ts
+++ b/server/src/events/performAction/turnManager.ts
@@ -4,6 +4,7 @@ import { GameRoom, ActionResult } from "../../types/game.types";
 import { ServerEvents } from "../../types/socket.types";
 import { updateStatStage, removeStatus } from "./utils/effects";
 import { broadcastRoomsList } from '../../utils/roomHelpers';
+import { sendSystemMessage } from '../../utils/messages';
 
 export function processTurn(
   io: Server,
@@ -24,13 +25,7 @@ export function processTurn(
           winnerId: winner.id,
           winnerUsername: winner.username
         });
-        io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
-          username: 'Sistema',
-          message: `El juego ha terminado. Ganador: ${winner.username}`,
-          timestamp: new Date(),
-          isSpectator: false,
-          isSystem: true
-        });
+        sendSystemMessage(io, playerRoom.id, `El juego ha terminado. Ganador: ${winner.username}`);
       }
       break;
     }
@@ -79,23 +74,19 @@ export function processTurn(
         activeChar.currentHealth = Math.max(0, activeChar.currentHealth - dmg);
         if (activeChar.currentHealth === 0) activeChar.isAlive = false;
         startEffects.push({ type: 'damage', target: 'source', value: dmg });
-        io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
-          username: 'Sistema',
-          message: `${activePlayer?.username} - ${activeChar.name} sufre ${dmg} de daño por quemadura`,
-          timestamp: new Date(),
-          isSpectator: false,
-          isSystem: true
-        });
+        sendSystemMessage(
+          io,
+          playerRoom.id,
+          `${activePlayer?.username} - ${activeChar.name} sufre ${dmg} de daño por quemadura`
+        );
       } else if (activeChar.status === 'paralysis') {
         if (Math.random() < 0.25) {
           skipTurn = true;
-          io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
-            username: 'Sistema',
-            message: `${activePlayer?.username} - ${activeChar.name} está paralizado y pierde el turno`,
-            timestamp: new Date(),
-            isSpectator: false,
-            isSystem: true
-          });
+          sendSystemMessage(
+            io,
+            playerRoom.id,
+            `${activePlayer?.username} - ${activeChar.name} está paralizado y pierde el turno`
+          );
         }
       } else if (activeChar.status === 'drunk') {
         const selfHit = Math.random() < 1 / 3;
@@ -104,13 +95,11 @@ export function processTurn(
           activeChar.currentHealth = Math.max(0, activeChar.currentHealth - dmg);
           if (activeChar.currentHealth === 0) activeChar.isAlive = false;
           startEffects.push({ type: 'damage', target: 'source', value: dmg });
-          io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
-            username: 'Sistema',
-            message: `${activePlayer?.username} - ${activeChar.name} se golpeó a sí mismo y perdió ${dmg} de vida`,
-            timestamp: new Date(),
-            isSpectator: false,
-            isSystem: true
-          });
+          sendSystemMessage(
+            io,
+            playerRoom.id,
+            `${activePlayer?.username} - ${activeChar.name} se golpeó a sí mismo y perdió ${dmg} de vida`
+          );
         }
         skipTurn = true;
       } else if (activeChar.status === 'sleep') {
@@ -121,22 +110,18 @@ export function processTurn(
         else if (activeChar.statusTurns >= 4) chance = 1;
         if (Math.random() < chance) {
           removeStatus(activeChar, startEffects, 'source');
-          io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
-            username: 'Sistema',
-            message: `${activePlayer?.username} - ${activeChar.name} se despertó`,
-            timestamp: new Date(),
-            isSpectator: false,
-            isSystem: true
-          });
+          sendSystemMessage(
+            io,
+            playerRoom.id,
+            `${activePlayer?.username} - ${activeChar.name} se despertó`
+          );
         } else {
           skipTurn = true;
-          io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
-            username: 'Sistema',
-            message: `${activePlayer?.username} - ${activeChar.name} está dormido`,
-            timestamp: new Date(),
-            isSpectator: false,
-            isSystem: true
-          });
+          sendSystemMessage(
+            io,
+            playerRoom.id,
+            `${activePlayer?.username} - ${activeChar.name} está dormido`
+          );
         }
       }
     }

--- a/server/src/events/ready.ts
+++ b/server/src/events/ready.ts
@@ -3,6 +3,7 @@ import config from '../config/config';
 import { GameRoom, Player } from '../types/game.types';
 import { ClientEvents, ServerEvents } from '../types/socket.types';
 import { broadcastRoomsList, findPlayerRoom } from '../utils/roomHelpers';
+import { sendSystemMessage } from '../utils/messages';
 
 export function registerReady(
   io: Server,
@@ -65,13 +66,7 @@ export function registerReady(
         room: playerRoom,
         turnOrder
       });
-      io.to(playerRoom.id).emit(ServerEvents.CHAT_MESSAGE, {
-        username: 'Sistema',
-        message: 'El juego ha comenzado',
-        timestamp: new Date(),
-        isSpectator: false,
-        isSystem: true
-      });
+      sendSystemMessage(io, playerRoom.id, 'El juego ha comenzado');
 
       io.to(playerRoom.id).emit(ServerEvents.TURN_STARTED, {
         playerId: turnOrder[0].playerId,

--- a/server/src/utils/messages.ts
+++ b/server/src/utils/messages.ts
@@ -1,0 +1,18 @@
+import { Server } from 'socket.io';
+import { ServerEvents } from '../types/socket.types';
+
+export function sendSystemMessage(
+  io: Server,
+  roomId: string,
+  message: string,
+  options: { isSpectator?: boolean; tooltip?: string } = {}
+) {
+  io.to(roomId).emit(ServerEvents.CHAT_MESSAGE, {
+    username: 'Sistema',
+    message,
+    timestamp: new Date(),
+    isSpectator: !!options.isSpectator,
+    isSystem: true,
+    ...(options.tooltip ? { tooltip: options.tooltip } : {})
+  });
+}


### PR DESCRIPTION
## Summary
- use `CharacterService` to load data in server index
- centralize system chat messages in new `sendSystemMessage` util
- refactor events to use the new helper

## Testing
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm test` in `rolmakelele` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c8772ee88327b112570c5d70264f