### PR TITLE
Fix turn order recalculation

### DIFF
--- a/rolmakelele/src/app/models/game.types.ts
+++ b/rolmakelele/src/app/models/game.types.ts
@@ -128,6 +128,8 @@ export interface GameRoom {
     playerId: string;
     characterIndex: number;
   };
+  /** Index in turnOrder pointing to currentTurn */
+  turnIndex?: number;
   turnOrder?: {
     playerId: string;
     characterIndex: number;

--- a/server/TODO.txt
+++ b/server/TODO.txt
@@ -1,8 +1,12 @@
 TODO
--cAMBIAR A SISTEMA DE NIVELES LO BUFFOS Y QUE NO SEA NUMERICO
--IMplementar prioridades
--programar estaados alterados: quemado, paralizado, borracho, dormido
+-revisar movimientos: 
+    -agitar coctelera - no aplica el buffo a los demas
+    -Tragito coctel - no aplica daño de vuelta
+    -Hacer cachimba - no carga un turno
+
 -programar habilidades 
+
+
 -Javi
     Tipo: Barman, Friki
     "speed": 200,

--- a/server/src/events/performAction/turnManager.ts
+++ b/server/src/events/performAction/turnManager.ts
@@ -43,12 +43,21 @@ export function processTurn(
       }
     }
 
-    playerRoom.turnOrder.sort((a, b) => b.speed - a.speed);
-    const currentTurnIndex = playerRoom.turnOrder.findIndex(
-      t => t.playerId === playerRoom.currentTurn?.playerId &&
-           t.characterIndex === playerRoom.currentTurn?.characterIndex
-    );
-    let nextTurnIndex = (currentTurnIndex + 1) % playerRoom.turnOrder.length;
+    let currentTurnIndex =
+      playerRoom.turnIndex ??
+      playerRoom.turnOrder.findIndex(
+        (t) =>
+          t.playerId === playerRoom.currentTurn?.playerId &&
+          t.characterIndex === playerRoom.currentTurn?.characterIndex,
+      );
+    if (currentTurnIndex < 0) currentTurnIndex = 0;
+
+    let nextTurnIndex = currentTurnIndex + 1;
+    const newRound = nextTurnIndex >= playerRoom.turnOrder.length;
+    if (newRound) {
+      playerRoom.turnOrder.sort((a, b) => b.speed - a.speed);
+      nextTurnIndex = 0;
+    }
     let nextTurn = playerRoom.turnOrder[nextTurnIndex];
     let safetyCounter = playerRoom.turnOrder.length;
     while (safetyCounter > 0) {
@@ -62,6 +71,7 @@ export function processTurn(
     }
 
     playerRoom.currentTurn = nextTurn;
+    playerRoom.turnIndex = nextTurnIndex;
 
     const activePlayer = playerRoom.players.find(p => p.id === nextTurn.playerId);
     const activeChar = activePlayer?.selectedCharacters[nextTurn.characterIndex];

--- a/server/src/events/performAction/validation.ts
+++ b/server/src/events/performAction/validation.ts
@@ -45,6 +45,14 @@ export function validateAction(
     return null;
   }
 
+  if (playerRoom.currentTurn.characterIndex !== data.sourceCharacterIndex) {
+    socket.emit(ServerEvents.ERROR, {
+      message: 'No es el turno de este personaje',
+      code: 'WRONG_CHARACTER_TURN'
+    });
+    return null;
+  }
+
   const sourcePlayer = playerRoom.players.find(p => p.id === socket.id);
   const targetPlayer = playerRoom.players.find(p => p.id === data.targetPlayerId);
 

--- a/server/src/events/ready.ts
+++ b/server/src/events/ready.ts
@@ -60,6 +60,7 @@ export function registerReady(
 
       turnOrder.sort((a, b) => b.speed - a.speed);
       playerRoom.turnOrder = turnOrder;
+      playerRoom.turnIndex = 0;
       playerRoom.currentTurn = turnOrder[0];
 
       io.to(playerRoom.id).emit(ServerEvents.GAME_STARTED, {

--- a/server/src/types/game.types.ts
+++ b/server/src/types/game.types.ts
@@ -124,6 +124,8 @@ export interface GameRoom {
     playerId: string;
     characterIndex: number;
   };
+  /** Index in turnOrder pointing to currentTurn */
+  turnIndex?: number;
   turnOrder?: {
     playerId: string;
     characterIndex: number;


### PR DESCRIPTION
## Summary
- maintain a turn index and recalc order only after a full round
- expose new `turnIndex` in server and client GameRoom types

## Testing
- `npm install`
- `npm run build`
- `cd rolmakelele && npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851d78b3b6c8327a54371e92f792cf1